### PR TITLE
Feat: Make studio embedding optional

### DIFF
--- a/apps/example/astro.config.mjs
+++ b/apps/example/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
       projectId: "3do82whm",
       dataset: "next",
       // If you are doing static builds you may want opt out of the CDN
-      useCdn: true,
+      useCdn: false,
       studioBasePath: "/admin",
     }),
     react()

--- a/packages/sanity-astro/index.ts
+++ b/packages/sanity-astro/index.ts
@@ -20,7 +20,7 @@ export type IntegrationOptions = ClientConfig & {
 };
 
 const defaultOptions: IntegrationOptions = {
-  apiVersion: "v2021-03-25",
+  apiVersion: "v2023-08-24",
 };
 export default function sanityIntegration(
   options: IntegrationOptions,

--- a/packages/sanity-astro/index.ts
+++ b/packages/sanity-astro/index.ts
@@ -9,7 +9,7 @@ declare global {
 export function useSanityClient(): SanityClient {
   if (!globalThis.sanityClientInstance) {
     console.error(
-      "[@sanity/astro]: sanityClientInstance has not been initialized correctly",
+      "[@sanity/astro]: sanityClientInstance has not been initialized correctly"
     );
   }
   return globalThis.sanityClientInstance;
@@ -22,8 +22,9 @@ export type IntegrationOptions = ClientConfig & {
 const defaultOptions: IntegrationOptions = {
   apiVersion: "v2023-08-24",
 };
+
 export default function sanityIntegration(
-  options: IntegrationOptions,
+  options: IntegrationOptions
 ): AstroIntegration {
   const resolvedOptions = {
     ...defaultOptions,
@@ -46,17 +47,20 @@ export default function sanityIntegration(
             ],
           },
         });
-        injectRoute({
-          entryPoint: "@sanity/astro/studio/studio-route.astro",
-          pattern: `/${resolvedOptions.studioBasePath}/[...params]`,
-          prerender: false,
-        });
+        // only load this route if `studioBasePath` is set
+        if (resolvedOptions.studioBasePath) {
+          injectRoute({
+            entryPoint: "@sanity/astro/studio/studio-route.astro",
+            pattern: `/${resolvedOptions.studioBasePath}/[...params]`,
+            prerender: false,
+          });
+        }
         injectScript(
           "page-ssr",
           `
           import { sanityClientInstance } from "virtual:sanity-init";
           globalThis.sanityClientInstance = sanityClientInstance;
-          `,
+          `
         );
       },
     },

--- a/packages/sanity-astro/index.ts
+++ b/packages/sanity-astro/index.ts
@@ -15,7 +15,9 @@ export function useSanityClient(): SanityClient {
   return globalThis.sanityClientInstance;
 }
 
-export type IntegrationOptions = ClientConfig;
+export type IntegrationOptions = ClientConfig & {
+  studioBasePath?: string;
+};
 
 const defaultOptions: IntegrationOptions = {
   apiVersion: "v2021-03-25",

--- a/packages/sanity-astro/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/vite-plugin-sanity-studio.ts
@@ -1,17 +1,6 @@
 import type { Plugin } from "vite";
 
 export function vitePluginSanityStudio(resolvedOptions, config): Plugin {
-  if (config.output !== "hybrid" && config.output !== "server") {
-    throw new Error(
-      "[@sanity/astro]: Sanity Studio requires `output: 'hybrid'` or `output: 'server'` in your Astro config",
-    );
-  }
-
-  if (!resolvedOptions.studioBasePath) {
-    throw new Error(
-      "[@sanity/astro]: The `studioBasePath` option is required in `astro.config.mjs`. For example — `studioBasePath: '/admin'`",
-    );
-  }
   const virtualModuleId = "virtual:sanity-studio";
   const resolvedVirtualModuleId = virtualModuleId;
 
@@ -25,12 +14,22 @@ export function vitePluginSanityStudio(resolvedOptions, config): Plugin {
     },
     async load(id: string) {
       if (id === "virtual:sanity-studio") {
+        if (config.output !== "hybrid" && config.output !== "server") {
+          throw new Error(
+            "[@sanity/astro]: Sanity Studio requires `output: 'hybrid'` or `output: 'server'` in your Astro config"
+          );
+        }
         const studioConfig = await this.resolve("/sanity.config");
         if (!studioConfig) {
-          console.error(
-            "[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root.",
+          throw new Error(
+            "[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root."
           );
           return null;
+        }
+        if (!resolvedOptions.studioBasePath) {
+          throw new Error(
+            "[@sanity/astro]: The `studioBasePath` option is required in `astro.config.mjs`. For example — `studioBasePath: '/admin'`"
+          );
         }
         return `
         import config from "${studioConfig.id}";


### PR DESCRIPTION
The logic in the plugin loading required everyone to set the `studioBasePath` and add `sanity.config.ts`. The intention with this feature was to be optional.

This PR makes `studioBasePath` the “switch” by skipping adding the studio route if not set. I also centralized the error handling so it's a bit easier to reason about when the plugin tries to load the Studio or not. I also replaced a console warning with an Error if `studioBasePath` is set without a config file so that folks are more likely to notice something wrong. 