### PR TITLE
Feature/add support for third party templating

### DIFF
--- a/apps/example-ssr/src/components/InternalLink.astro
+++ b/apps/example-ssr/src/components/InternalLink.astro
@@ -1,16 +1,15 @@
 ---
-import { useSanityClient } from "@sanity/astro";
+import { sanityClient } from "sanity:client";
 const { node } = Astro.props;
 const { markDef } = node;
 
-const client = useSanityClient();
 // Only deal with posts links for this example
-const destination = markDef._ref && await client.fetch(
+const destination = markDef._ref && await sanityClient.fetch(
   `* [_type == "post" && _id == $id] {slug {current}}[0]`,
   { id: markDef._ref }
 );
 
-const linkText = node.children.map(c => c.text).join(' ')
+const linkText = node.children.map((c: any) => c.text).join(' ')
 ---
 
 {

--- a/apps/example-ssr/src/components/NewsBar.jsx
+++ b/apps/example-ssr/src/components/NewsBar.jsx
@@ -1,0 +1,29 @@
+/**
+ * A dynamic Newsbar that fetches content live from Sanity.
+ *
+ */
+import { useState, useEffect, useCallback } from "react";
+import { sanityClient } from "sanity:client";
+
+export function NewsBar() {
+  const [news, setNews] = useState({ message: "Loading news…" });
+  const client = sanityClient;
+  const getNews = useCallback(async () => {
+    const response = await client.fetch(
+      `*[_type == "sanityIoSettings"][0].banner`
+    );
+    setNews(response || { message: "no news" });
+  }, [client]);
+
+  useEffect(() => {
+    getNews();
+  }, [getNews]);
+
+  return (
+    <marquee style={{ background: "blue", padding: "1em" }}>
+      <a style={{ color: "white" }} href={`https://www.sanity.io/${news.link}`}>
+        {news.message}
+      </a>
+    </marquee>
+  );
+}

--- a/apps/example-ssr/src/components/SanityImage.astro
+++ b/apps/example-ssr/src/components/SanityImage.astro
@@ -1,9 +1,8 @@
 ---
 import imageUrlBuilder from "@sanity/image-url";
-import {useSanityClient} from "@sanity/astro"
+import {sanityClient} from "sanity:client"
 
-const client = useSanityClient()
-const builder = imageUrlBuilder(client)
+const builder = imageUrlBuilder(sanityClient)
 
 const {node} = Astro.props
 const { width = 960 } = Astro.props
@@ -11,11 +10,11 @@ const { width = 960 } = Astro.props
 // See https://www.sanity.io/docs/presenting-images for general documentation on
 // presenting images, and https://www.sanity.io/docs/image-url for specifics on
 // this builder API
-const image = builder
+const image = node && builder
   .image(node)
   .width(width)
   .fit('max')
   .auto('format')
 ---
 
-<img src={image.url()} alt={node.alt || ""} title={node.alt} />
+{image && <img src={image.url()} alt={node.alt || ""} title={node.alt} />}

--- a/apps/example-ssr/src/layouts/Layout.astro
+++ b/apps/example-ssr/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
---- 
+---
+import { NewsBar } from '../components/NewsBar';
+
 interface Props {
 	title: string;
 }
@@ -17,6 +19,7 @@ const { title } = Astro.props;
 		<title>{title}</title>
 	</head>
 	<body>
+		<NewsBar client:only="react" />
 		<slot />
 	</body>
 </html>

--- a/apps/example-ssr/src/pages/index.astro
+++ b/apps/example-ssr/src/pages/index.astro
@@ -1,27 +1,19 @@
 ---
-import { useSanityClient } from "@sanity/astro";
+import { sanityClient } from "sanity:client";
+import Layout from "../layouts/Layout.astro";
 
-const client = useSanityClient();
-const posts = await client.fetch(`*[_type == "post" && defined(publishedAt)] | order(publishedAt desc)`);
+const posts = await sanityClient.fetch(`*[_type == "post" && defined(publishedAt)] | order(publishedAt desc)`);
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Sanity.io blog</title>
-	</head>
-	<body>
+<Layout title="Sanity.io blog">
 		<h1>Sanity.io blog</h1>
 		<ul>
-			{posts.map((post) => (
-				<li>,
+			{posts.map((post: any) => (
+				<li>
 					<a href={'/posts/' + post.slug.current} class="post-link">
 						{post.title}
 					</a>
 				</li>
 			))}
-	</body>
-</html>
+			</ul>
+</Layout>

--- a/apps/example-ssr/src/pages/posts/[slug].astro
+++ b/apps/example-ssr/src/pages/posts/[slug].astro
@@ -1,20 +1,19 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import { useSanityClient } from "@sanity/astro";
+import { sanityClient } from "sanity:client";
 import PortableText from "../../components/PortableText.astro";
 import SanityImage from "../../components/SanityImage.astro";
 
-  const client = useSanityClient();
-  const post = await client.fetch(
-    `*[_type == "post" && defined(publishedAt) && slug.current == $slug] | order(publishedAt desc) {
-			...,
-			authors[]-> {
-				name
-			}
-		}[0]`, {
-      slug: Astro.params.slug,
+const post = await sanityClient.fetch(
+  `*[_type == "post" && defined(publishedAt) && slug.current == $slug] | order(publishedAt desc) {
+    ...,
+    authors[]-> {
+      name
     }
-  );
+  }[0]`, {
+    slug: Astro.params.slug,
+  }
+);
 
 const byline = (post.authors || []).map((a:any) => a.name).join(", ");
 ---

--- a/apps/example/sanity.config.ts
+++ b/apps/example/sanity.config.ts
@@ -1,11 +1,10 @@
 import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
 import { deskTool } from "sanity/desk";
+import { sanityClient } from "sanity:client";
 import { schemaTypes } from "./schemas";
 
-export const projectId =
-  import.meta.env.PUBLIC_SANITY_PROJECT_ID! || "3do82whm";
-export const dataset = import.meta.env.PUBLIC_SANITY_DATASET! || "next";
+const { projectId, dataset } = sanityClient.config();
 
 export default defineConfig({
   name: "project-name",

--- a/apps/example/src/components/InternalLink.astro
+++ b/apps/example/src/components/InternalLink.astro
@@ -1,16 +1,15 @@
 ---
-import { useSanityClient } from "@sanity/astro";
+import { sanityClient } from "sanity:client";
 const { node } = Astro.props;
 const { markDef } = node;
 
-const client = useSanityClient();
 // Only deal with posts links for this example
-const destination = markDef._ref && await client.fetch(
+const destination = markDef._ref && await sanityClient.fetch(
   `* [_type == "post" && _id == $id] {slug {current}}[0]`,
   { id: markDef._ref }
 );
 
-const linkText = node.children.map(c => c.text).join(' ')
+const linkText = node.children.map((c: any) => c.text).join(' ')
 ---
 
 {

--- a/apps/example/src/components/NewsBar.jsx
+++ b/apps/example/src/components/NewsBar.jsx
@@ -1,0 +1,29 @@
+/**
+ * A dynamic Newsbar that fetches content live from Sanity.
+ *
+ */
+import { useState, useEffect, useCallback } from "react";
+import { sanityClient } from "sanity:client";
+
+export function NewsBar() {
+  const [news, setNews] = useState({ message: "Loading news…" });
+  const client = sanityClient;
+  const getNews = useCallback(async () => {
+    const response = await client.fetch(
+      `*[_type == "sanityIoSettings"][0].banner`
+    );
+    setNews(response || { message: "no news" });
+  }, [client]);
+
+  useEffect(() => {
+    getNews();
+  }, [getNews]);
+
+  return (
+    <marquee style={{ background: "blue", padding: "1em" }}>
+      <a style={{ color: "white" }} href={`https://www.sanity.io/${news.link}`}>
+        {news.message}
+      </a>
+    </marquee>
+  );
+}

--- a/apps/example/src/components/SanityImage.astro
+++ b/apps/example/src/components/SanityImage.astro
@@ -1,9 +1,9 @@
 ---
 import imageUrlBuilder from "@sanity/image-url";
-import {useSanityClient} from "@sanity/astro"
+import { sanityClient } from "sanity:client";
 
-const client = useSanityClient()
-const builder = imageUrlBuilder(client)
+
+const builder = imageUrlBuilder(sanityClient)
 
 const {node} = Astro.props
 const { width = 960 } = Astro.props
@@ -11,11 +11,11 @@ const { width = 960 } = Astro.props
 // See https://www.sanity.io/docs/presenting-images for general documentation on
 // presenting images, and https://www.sanity.io/docs/image-url for specifics on
 // this builder API
-const image = builder
+const image = node && builder
   .image(node)
   .width(width)
   .fit('max')
   .auto('format')
 ---
 
-<img src={image.url()} alt={node.alt || ""} title={node.alt} />
+{image && <img src={image.url()} alt={node.alt || ""} title={node.alt} />}

--- a/apps/example/src/layouts/Layout.astro
+++ b/apps/example/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
---- 
+---
+import { NewsBar } from '../components/NewsBar';
+
 interface Props {
 	title: string;
 }
@@ -17,6 +19,7 @@ const { title } = Astro.props;
 		<title>{title}</title>
 	</head>
 	<body>
+		<NewsBar client:only="react" />
 		<slot />
 	</body>
 </html>

--- a/apps/example/src/pages/index.astro
+++ b/apps/example/src/pages/index.astro
@@ -1,27 +1,21 @@
 ---
-import { useSanityClient } from "@sanity/astro";
+import {sanityClient}  from "sanity:client";
+import { NewsBar } from "../components/NewsBar";
+import Layout from "../layouts/Layout.astro";
 
-const client = useSanityClient();
+const client = sanityClient;
 const posts = await client.fetch(`*[_type == "post" && defined(publishedAt)] | order(publishedAt desc)`);
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Sanity.io blog</title>
-	</head>
-	<body>
+<Layout title="Sanity.io blog">
 		<h1>Sanity.io blog</h1>
 		<ul>
 			{posts.map((post: any) => (
-				<li>,
+				<li>
 					<a href={'/posts/' + post.slug.current} class="post-link">
 						{post.title}
 					</a>
 				</li>
 			))}
-	</body>
-</html>
+	</ul>
+</Layout>

--- a/apps/example/src/pages/index.astro
+++ b/apps/example/src/pages/index.astro
@@ -1,10 +1,8 @@
 ---
 import {sanityClient}  from "sanity:client";
-import { NewsBar } from "../components/NewsBar";
 import Layout from "../layouts/Layout.astro";
 
-const client = sanityClient;
-const posts = await client.fetch(`*[_type == "post" && defined(publishedAt)] | order(publishedAt desc)`);
+const posts = await sanityClient.fetch(`*[_type == "post" && defined(publishedAt)] | order(publishedAt desc)`);
 ---
 
 <Layout title="Sanity.io blog">

--- a/apps/example/src/pages/posts/[slug].astro
+++ b/apps/example/src/pages/posts/[slug].astro
@@ -5,8 +5,7 @@ import PortableText from "../../components/PortableText.astro";
 import SanityImage from "../../components/SanityImage.astro";
 
 export async function getStaticPaths() {
-  const client = sanityClient;
-  const posts = await client.fetch(
+  const posts = await sanityClient.fetch(
     `*[_type == "post" && defined(publishedAt)] | order(publishedAt desc) {
 			...,
 			authors[]-> {

--- a/apps/example/src/pages/posts/[slug].astro
+++ b/apps/example/src/pages/posts/[slug].astro
@@ -1,11 +1,11 @@
 ---
+import { sanityClient } from "sanity:client";
 import Layout from "../../layouts/Layout.astro";
-import { useSanityClient } from "@sanity/astro";
 import PortableText from "../../components/PortableText.astro";
 import SanityImage from "../../components/SanityImage.astro";
 
 export async function getStaticPaths() {
-  const client = useSanityClient();
+  const client = sanityClient;
   const posts = await client.fetch(
     `*[_type == "post" && defined(publishedAt)] | order(publishedAt desc) {
 			...,

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -50,7 +50,7 @@ export default defineConfig({
 });
 ```
 
-This enables the use of `sanityClient()` in your template files. For example:
+This enables the use of `sanityClient` in your template files. For example:
 
 ```mdx
 ---

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -72,7 +72,7 @@ const posts = await sanityClient.fetch(`*[_type == "post" && defined(slug)] | or
 </ul>
 ```
 
-[Check out this guide][guide] for a more elaborate introduction to how to integrate content from Sanity into Astro.
+[Check out this guide][guide] for a more elaborate introduction to how to integrate content from Sanity into Astro. You can also look in the `examples` folder in this repository for complete implementation examples.
 
 ### Embedding Sanity Studio on a route
 

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -50,15 +50,14 @@ export default defineConfig({
 });
 ```
 
-This enables the use of `useSanityClient()` in your template files. For example:
+This enables the use of `sanityClient()` in your template files. For example:
 
 ```mdx
 ---
 // /blog/index.astro
-import { useSanityClient } from "@sanity/astro";
+import { sanityClient } from "sanity:client";
 
-const client = useSanityClient();
-const posts = await client.fetch(`*[_type == "post" && defined(slug)] | order(publishedAt desc)`);
+const posts = await sanityClient.fetch(`*[_type == "post" && defined(slug)] | order(publishedAt desc)`);
 ---
 
 <h1>Blog</h1>
@@ -114,14 +113,14 @@ You can use this configuration file to install plugins, add a schema with docume
 
 ```javascript
 // astro.config.mjs
-import sanityIntegration from "@sanity/astro";
+import sanity from "@sanity/astro";
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 
 export default defineConfig({
   output: "hybrid",
   integrations: [
-    sanityIntegration({
+    sanity({
       projectId: "3do82whm",
       dataset: "next",
       // Set useCdn to false if you're building statically.

--- a/packages/sanity-astro/studio/StudioComponent.tsx
+++ b/packages/sanity-astro/studio/StudioComponent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // @ts-ignore
-import config from "virtual:sanity-studio";
+import { config } from "sanity:studio";
 import { Studio } from "sanity";
 
 // import { useTheme } from "./useTheme";
@@ -8,7 +8,7 @@ import { Studio } from "sanity";
 
 if (!config) {
   throw new Error(
-    "[@sanity/astro]: Can't load Sanity Studio. Check that you've configured it in `sanity.config.js|ts`.",
+    "[@sanity/astro]: Can't load Sanity Studio. Check that you've configured it in `sanity.config.js|ts`."
   );
 }
 

--- a/packages/sanity-astro/studio/usePrefersColorScheme.ts
+++ b/packages/sanity-astro/studio/usePrefersColorScheme.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import type { ThemeColorSchemeKey } from "@sanity/ui";
 import { useSyncExternalStore } from "react";
 
@@ -29,6 +28,6 @@ export function usePrefersColorScheme(): ThemeColorSchemeKey {
   return useSyncExternalStore(
     store.subscribe,
     store.getSnapshot,
-    store.getServerSnapshot,
+    store.getServerSnapshot
   );
 }

--- a/packages/sanity-astro/studio/useTheme.ts
+++ b/packages/sanity-astro/studio/useTheme.ts
@@ -4,13 +4,13 @@ import type { Config, SingleWorkspace, StudioTheme } from "sanity";
 
 /** @alpha */
 export function useTheme(
-  config?: Config | Required<Pick<SingleWorkspace, "theme">>,
+  config?: Config | Required<Pick<SingleWorkspace, "theme">>
 ): StudioTheme {
   const workspace = useMemo<
     SingleWorkspace | Required<Pick<SingleWorkspace, "theme">> | undefined
   >(() => (Array.isArray(config) ? config[0] : config), [config]);
   return useMemo<StudioTheme>(
     () => workspace?.theme || studioTheme,
-    [workspace],
+    [workspace]
   );
 }

--- a/packages/sanity-astro/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/vite-plugin-sanity-client.ts
@@ -1,12 +1,12 @@
 import type { ClientConfig } from "@sanity/client";
 import type { Plugin } from "vite";
 
-export function vitePluginSanityInit(config: ClientConfig): Plugin {
-  const virtualModuleId = "virtual:sanity-init";
-  const resolvedVirtualModuleId = "\0" + virtualModuleId;
+const virtualModuleId = "sanity:client";
+const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
+export function vitePluginSanityClient(config: ClientConfig): Plugin {
   return {
-    name: "vite-plugin-sanity-init",
+    name: "vite-plugin-sanity-client",
     resolveId(id: string) {
       if (id === virtualModuleId) {
         return resolvedVirtualModuleId;
@@ -16,7 +16,7 @@ export function vitePluginSanityInit(config: ClientConfig): Plugin {
       if (id === resolvedVirtualModuleId) {
         return `
           import { createClient } from "@sanity/client";
-          export const sanityClientInstance = createClient(
+          export const sanityClient = createClient(
             ${JSON.stringify(config)}
           );
         `;

--- a/packages/sanity-astro/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/vite-plugin-sanity-studio.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "vite";
 
-export function vitePluginSanityStudio(resolvedOptions, config): Plugin {
-  const virtualModuleId = "virtual:sanity-studio";
+export function vitePluginSanityStudio(resolvedOptions, { output }): Plugin {
+  const virtualModuleId = "sanity:studio";
   const resolvedVirtualModuleId = virtualModuleId;
 
   return {
@@ -13,38 +13,40 @@ export function vitePluginSanityStudio(resolvedOptions, config): Plugin {
       return null;
     },
     async load(id: string) {
-      if (id === "virtual:sanity-studio") {
-        if (config.output !== "hybrid" && config.output !== "server") {
+      if (id === virtualModuleId) {
+        if (output !== "hybrid" && output !== "server") {
           throw new Error(
-            "[@sanity/astro]: Sanity Studio requires `output: 'hybrid'` or `output: 'server'` in your Astro config",
+            "[@sanity/astro]: Sanity Studio requires `output: 'hybrid'` or `output: 'server'` in your Astro config"
           );
         }
         const studioConfig = await this.resolve("/sanity.config");
         if (!studioConfig) {
           throw new Error(
-            "[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root.",
+            "[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root."
           );
           return null;
         }
         if (!resolvedOptions.studioBasePath) {
           throw new Error(
-            "[@sanity/astro]: The `studioBasePath` option is required in `astro.config.mjs`. For example — `studioBasePath: '/admin'`",
+            "[@sanity/astro]: The `studioBasePath` option is required in `astro.config.mjs`. For example — `studioBasePath: '/admin'`"
           );
         }
         return `
-        import config from "${studioConfig.id}";
-        if (config.basePath) {
-          if (config.basePath !== "/${resolvedOptions.studioBasePath}") {
+        import studioConfig from "${studioConfig.id}";
+
+        if (studioConfig.basePath) {
+          if (studioConfig.basePath !== "/${resolvedOptions.studioBasePath}") {
             console.warn(
               "[@sanity/astro]: This integration ignores the basePath setting in sanity.config.ts|js. To set the basePath for Sanity Studio, use the studioBasePath option in astro.config.mjs and remove it from sanity.config.ts.");
           }
         }
 
-        export default {
-          ...config,
+        export const config = {
+          ...studioConfig,
           // override basePath from sanity.config.ts|js with plugin setting
-          basePath: "/${resolvedOptions.studioBasePath}",
-        }`;
+          basePath: "${resolvedOptions.studioBasePath}",
+        }
+        `;
       }
       return null;
     },


### PR DESCRIPTION
I started digging into https://github.com/sanity-io/sanity-astro/issues/59 and noticed that we could simplify the developer experience of this plugin and bring it closer to the Astro conventions:

Removes the useSanityClient() hook. It caused problems when imported into client-side non-Astro files
Introduces the import { sanityClient } from 'sanity:client' pattern, which works across .astro and non-.astro files
Adds a JSX component with client-side data-fetching to the example
This is a breaking change since it deprecates the useSanityClient hook.

Some commits in this PR intentionally don't follow Vite plugin conventions in favor of adopting Astro integration conventions.

I think I managed to include typing support for the modules, but that is a thing to double-check.