### PR TITLE
Narration sd/module exports astro 3 and 4

### DIFF
--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -13,14 +13,12 @@
     "src/studio",
     "module.d.ts"
   ],
-  "module": "./dist/sanity-astro.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "module": "./dist/sanity-astro.js",
+      "module": "./dist/sanity-astro.mjs",
       "default": "./dist/sanity-astro.mjs"
     },
-    "./module": "./module.d.ts",
     "./studio/studio-route.astro": "./dist/studio/studio-route.astro",
     "./studio/studio-component.tsx": {
       "types": "./src/studio/studio-component.tsx",

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/astro",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Official Sanity Astro integration",
   "scripts": {
     "dev": "vite build --watch",


### PR DESCRIPTION
This PR should complete the Astro 4 upgrade of @sanity/astro, by correcting subtle problems in the module exports.

It maintains compatibility with Astro 3, and in fact improves for that release.

It's been tested across a variety of Astro 4 and 3 configurations, using the original examples, then the advancing sanity-astro-preview, to become sanity-astro-presentation package. Both internal and installed package arrangements, and also Netlify deployment have been validated.

The changes appear simple here. The consequences of not having them will be failures in important configurations while not in others, giving a first appearance of 'working', and the error messaging where failing will not be helpful, leading to the investigation at several levels which results in this PR's upgrades.