### PR TITLE
Module connections refashioned, to fix issue #135

### DIFF
--- a/apps/example-ssr/.gitignore
+++ b/apps/example-ssr/.gitignore
@@ -19,3 +19,5 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+.vercel

--- a/apps/example-ssr/.gitignore
+++ b/apps/example-ssr/.gitignore
@@ -2,6 +2,7 @@
 dist/
 # generated types
 .astro/
+src/env.d.ts
 
 # dependencies
 node_modules/

--- a/apps/example-ssr/src/env.d.ts
+++ b/apps/example-ssr/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/apps/example-ssr/src/sani.d.ts
+++ b/apps/example-ssr/src/sani.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@sanity/astro/module" />

--- a/apps/example/.gitignore
+++ b/apps/example/.gitignore
@@ -2,6 +2,7 @@
 dist/
 # generated types
 .astro/
+src/env.d.ts
 
 # dependencies
 node_modules/

--- a/apps/example/src/env.d.ts
+++ b/apps/example/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/apps/example/src/sani.d.ts
+++ b/apps/example/src/sani.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@sanity/astro/module" />

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -2,6 +2,8 @@
 
 This integration enables the [Sanity Client][sanity-client] in your [Astro][astro] project and lets you embed Sanity Studio on a route. Astro is an all-in-one web framework that supports a range of UI languages and can be deployed in most places.
 
+_n.b. please be sure to follow the revised instructions which you'll find [here](###-Adding-types-for-`sanity:client`), to complete or upgrade an installation after Version 2.1.4..._
+
 - [Installation](#installation)
   - [Manual installation of dependencies](#manual-installation-of-dependencies)
   - [Adding types for `sanity:client`](#adding-types-for-sanityclient)
@@ -30,14 +32,17 @@ npm install @astrojs/react @sanity/astro @types/react-dom @types/react react-dom
 
 ### Adding types for `sanity:client`
 
-This integration leverages [Vite.js' virtual modules][vite-virtual-modules] with Astro's naming convention (e.g. `astro:assets`). Since it's not possible to automatically include module declarations from npm packages, you'll have to add the following line to the `env.d.ts` file that usually resides in the `src` folder of an Astro project:
+This integration leverages [Vite.js' virtual modules][vite-virtual-modules] with Astro's naming convention (e.g. `astro:assets`). Since it's not possible to automatically include module declarations from npm packages, you'll have to add a file with the following line at the top of the `src` folder of an Astro project:
 
 ```dts
-/// <reference types="astro/client" />
 /// <reference types="@sanity/astro/module" />
 ```
 
-You might have to restart the TS Server running in your code editor to get it to resolve types after updating this file. The easiest way to do this is to restart the application.
+The name of the file must be in the form `sani.d.ts`, as you find in each of the examples. Do not edit the env.d.ts file you may find there, as that file belongs to Astro, and may be updated or deleted. 
+
+If you have added such a line to an env.d.ts, you should now take it out, leaving the rest.You may however alter the 'sani' part of the filename you add, if desired.
+
+You might have to restart the TS Server running in your code editor to get it to resolve types after creating this file. The easiest way to do this is to restart the application.
 
 ## Usage
 

--- a/packages/sanity-astro/module.d.ts
+++ b/packages/sanity-astro/module.d.ts
@@ -1,0 +1,13 @@
+// exporting this on its own seems the only way to provide it with a package
+// it's critical to match it by providing a sani.d.ts file at the top of your
+// app src folder, with the following one line (begins with the triple-/)
+//
+//       /// <reference types="@sanity/astro/module" />
+
+declare module "sanity:client" {
+  export const sanityClient: import("@sanity/client").SanityClient;
+}
+
+declare module "sanity:studio" {
+  export const studioConfig: import("sanity").Config;
+}

--- a/packages/sanity-astro/module.d.ts
+++ b/packages/sanity-astro/module.d.ts
@@ -1,7 +1,0 @@
-declare module "sanity:client" {
-  export const sanityClient: import("@sanity/client").SanityClient;
-}
-
-declare module "sanity:studio" {
-  export const studioConfig: import("sanity").Config;
-}

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -10,9 +10,9 @@
   },
   "files": [
     "dist",
-    "src/studio",
-    "module.d.ts"
+    "src/studio"
   ],
+  "typs": "module",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -25,7 +25,6 @@
       "default": "./src/studio/studio-component.tsx"
     }
   },
-  "types": "./dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/sanity-io/sanity-astro.git",

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -10,15 +10,17 @@
   },
   "files": [
     "dist",
-    "src/studio"
+    "src/studio",
+    "module.d.ts"
   ],
-  "typs": "module",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
       "module": "./dist/sanity-astro.mjs",
       "default": "./dist/sanity-astro.mjs"
     },
+    "./module": "./module.d.ts",
     "./studio/studio-route.astro": "./dist/studio/studio-route.astro",
     "./studio/studio-component.tsx": {
       "types": "./src/studio/studio-component.tsx",

--- a/packages/sanity-astro/src/env.d.ts
+++ b/packages/sanity-astro/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../module.d.ts" />

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -3,16 +3,6 @@ import { vitePluginSanityClient } from "./vite-plugin-sanity-client";
 import { vitePluginSanityStudio } from "./vite-plugin-sanity-studio";
 import type { ClientConfig } from "@sanity/client";
 
-// declaring these here will cause them to appear in unified dist/types/index.d.ts
-// importing the module.d.ts containing them would not, unreasonably....
-declare module "sanity:client" {
-  export const sanityClient: import("@sanity/client").SanityClient;
-}
-
-declare module "sanity:studio" {
-  export const studioConfig: import("sanity").Config;
-}
-
 type IntegrationOptions = ClientConfig & {
   studioBasePath?: string;
 };

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -3,6 +3,16 @@ import { vitePluginSanityClient } from "./vite-plugin-sanity-client";
 import { vitePluginSanityStudio } from "./vite-plugin-sanity-studio";
 import type { ClientConfig } from "@sanity/client";
 
+// declaring these here will cause them to appear in unified dist/types/index.d.ts
+// importing the module.d.ts containing them would not, unreasonably....
+declare module "sanity:client" {
+  export const sanityClient: import("@sanity/client").SanityClient;
+}
+
+declare module "sanity:studio" {
+  export const studioConfig: import("sanity").Config;
+}
+
 type IntegrationOptions = ClientConfig & {
   studioBasePath?: string;
 };

--- a/packages/sanity-astro/tsconfig.json
+++ b/packages/sanity-astro/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "extends": "astro/tsconfigs/base",
   "$schema": "https://json.schemastore.org/tsconfig",
-  "include": ["./*.astro", "./**/*.ts"],
+  "include": ["./*.astro", "./*.ts","./**/*.ts"],
   "exclude": ["node_modules/*", "./vite*.ts", "dist"],
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "baseUrl": "src",
     "outDir": "./dist",

--- a/packages/sanity-astro/vite.config.ts
+++ b/packages/sanity-astro/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, Plugin } from "vite";
+import {defineConfig, Plugin} from "vite";
 import path from "path";
 import dts from "vite-plugin-dts";
 
@@ -16,6 +16,10 @@ export default defineConfig(() => {
     },
     plugins: [
       dts({
+        exclude: [
+          './src/vite-plugin-sanity-client.ts',
+          './src/vite-plugin-sanity-studio.ts'
+        ],
         outDir: "dist/types",
       }) as unknown as Plugin,
     ],


### PR DESCRIPTION
The previous update brought dependable Astro 4 compatibility to @sanity/astro, and passes many tests, including for Astro 3 and type checkers.. 

However, there's a recent Astro feature persons are adding to their build scripts, as 'astro check'. This checker halts builds by reporting errors in `@sanity-astro`, causing the #135 error reports.

This problem has to do with the linkage for the package's colon-named imports such as from `sanity:client`. The arrangement for these has been a rather hazy one, if successfully handled by Vite without explicit help in the last release. 

I've improved the situation by bring back the least potentially harmful, if non-standard, explicit help from the original. This re-introduces a 'module:' attribute in the exports: section of the package file, along with a files: mention for its target.

The 'module:' information is in turn used to give a reference hint to TypeScript and Vite, which is sufficient to pass even the Astro `check`'s type checker. 

We shouldn't, however, have ever used the `env.d.ts` files that magically appear after builds for this reference - they belong to Astro's creation, thus also could be over-written at any time, erasing our usage. I've instead added `sani.d.ts` files of our own for the references, and revised the Readme to instruct using them. I've also removed the `env.d.ts` files from Git attention.

Besides passing the Astro `check` now, and `eslint` as ever, the code changes for this PR have  been tested against Astro 3 and 4, including deployments to Netlify, which has been the most sensitive test of potential issues. As well, it's passed the test of being independently implemented on their local problem repo by a nicely informative persons reporting on the issue. 

These tests have been done via a temporarily published package on `@narration-sd/sanity-astro`, using source configuration adapted for it, described [here](https://github.com/sanity-io/sanity-astro/issues/135#issuecomment-1880404126) in the issue responses.