### PR TITLE
fix(module): add back missing module export

### DIFF
--- a/apps/example-ssr/src/env.d.ts
+++ b/apps/example-ssr/src/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference types="@sanity/astro/module" />

--- a/apps/example/src/env.d.ts
+++ b/apps/example/src/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference types="@sanity/astro/module" />

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -19,6 +19,7 @@
       "module": "./dist/sanity-astro.mjs",
       "default": "./dist/sanity-astro.mjs"
     },
+    "./module": "./module.d.ts",
     "./studio/studio-route.astro": "./dist/studio/studio-route.astro",
     "./studio/studio-component.tsx": {
       "types": "./src/studio/studio-component.tsx",


### PR DESCRIPTION
Hello team 🏄🏻 !

tldr;

This PR intends to fix the issue where importing from `sanity:client` throws an error, despite the correct triple-slash directive in `env.d.ts`. Should resolve #135.
![CleanShot 2024-01-17 at 00 23 24](https://github.com/sanity-io/sanity-astro/assets/10125940/36bda9d4-8113-4be7-83f3-537656d6323f)

More info:

I've realised, that `/// <reference types="@sanity/astro/module" />` did not actually link to anywhere when doing a `⌘ + Click`. 

Upon this discovery, I've noticed, that on `v2.2.0` the export pointing to the `module.d.ts` file has been removed, leading to a reference to nowhere and the files contents not being imported.

I've forked the package and linked to it locally, validating that once the export is added back it works.