### PR TITLE
feat!: Remove requirement for hybrid/server rendering

### DIFF
--- a/apps/example/astro.config.mjs
+++ b/apps/example/astro.config.mjs
@@ -1,7 +1,6 @@
 import { sanityIntegration } from "@sanity/astro";
 import { defineConfig } from "astro/config";
 import react from '@astrojs/react';
-import vercel from '@astrojs/vercel/serverless';
 
 // https://astro.build/config
 export default defineConfig({
@@ -15,6 +14,4 @@ export default defineConfig({
     }),
     react()
   ],
-  output: 'hybrid',
-  adapter: vercel(),
 });

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -13,7 +13,6 @@
     "@astro-community/astro-embed-youtube": "^0.4.1",
     "@astrojs/prism": "^3.0.0",
     "@astrojs/react": "^3.0.4",
-    "@astrojs/vercel": "^7.3.4",
     "@sanity/astro": "*",
     "@sanity/image-url": "^1.0.2",
     "@sanity/vision": "^3.19.0",

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -119,7 +119,6 @@ export default defineConfig({
 You can use this configuration file to install plugins, add a schema with document types, add customizations etc. Note that the Studio will be using Astro‘s development server which is built on top of [Vite][vite].
 
 1. Add the following to your `astro.config.mjs`:
-   - `output: 'hybrid'`: Required since the Studio is a client-side application.
    - `studioBasePath: '/admin'`: The route/path for where you want to access your studio
    - Import the [React integration for Astro][astro-react], and add it to the `integrations` array.
 
@@ -130,7 +129,6 @@ import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 
 export default defineConfig({
-  output: "hybrid",
   integrations: [
     sanityIntegration({
       projectId: "3do82whm",
@@ -145,9 +143,7 @@ export default defineConfig({
 });
 ```
 
-2. Since you have set `output: 'hybrid'` (or `server`), you have to add a deployment adapter to your Astro config as well. [Astro offers a range of adapters][adapter] depending on where you want to host your website.
-
-3. You have to [enable CORS origins for authenticated requests][cors] for the domains you're running your website project on. The Studio should automatically detect and let you add this when you access the Studio on a new URL. Typically you need to add your local development server URL and your production URL to the CORS origin settings. It's important that you only enable CORS for authenticated requests on domains that _you_ control.
+2. You have to [enable CORS origins for authenticated requests][cors] for the domains you're running your website project on. The Studio should automatically detect and let you add this when you access the Studio on a new URL. Typically you need to add your local development server URL and your production URL to the CORS origin settings. It's important that you only enable CORS for authenticated requests on domains that _you_ control.
 
 ## Rendering rich text and block content with Portable Text
 
@@ -206,7 +202,6 @@ You can also use community-contributed integrations like [astro-sanity-picture][
 [astro-portabletext]: https://github.com/theisel/astro-portabletext
 [cors]: https://www.sanity.io/docs/cors
 [vite]: https://vitejs.dev
-[adapter]: https://docs.astro.build/en/guides/server-side-rendering/#converting-a-static-site-to-hybrid-rendering
 [portabletext]: https://portabletext.org
 [image-document]: https://www.sanity.io/docs/image-metadata
 [astro-sanity-picture]: https://github.com/otterdev-io/astro-sanity-picture

--- a/packages/sanity-astro/src/studio/studio-route.astro
+++ b/packages/sanity-astro/src/studio/studio-route.astro
@@ -1,8 +1,11 @@
 ---
-import {StudioComponent} from './studio-component';
-export const prerender = false;
+import { StudioComponent } from "./studio-component"
+export async function getStaticPaths() {
+  return [{ params: { path: "admin" } }]
+}
 ---
-<!DOCTYPE html>
+
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -11,17 +14,17 @@ export const prerender = false;
       name="viewport"
       content="width=device-width,initial-scale=1,viewport-fit=cover"
     />
-    <link rel="icon" type="image/svg+xml"
-      href="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg width='512' height='512' viewBox='0 0 512 512' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='512' height='512' fill='%23F03E2F' rx='30' /%3E%3Cpath d='M161.527 136.723C161.527 179.76 187.738 205.443 240.388 219.095L296 232.283C345.687 243.852 376 272.775 376 319.514C376 341.727 369.162 360.931 357.538 375.971C357.538 329.232 333.607 303.78 276.171 288.74L221.47 276.246C177.709 266.065 143.977 242.464 143.977 191.56C143.977 170.505 150.359 151.994 161.527 136.723Z' fill='white' /%3E%3Cpath opacity='0.5' d='M323.35 308.176C347.054 323.679 357.538 345.197 357.538 376.202C337.709 401.654 303.293 416 262.724 416C194.575 416 146.484 381.756 136 322.753H201.641C210.074 350.056 232.41 362.551 262.268 362.551C298.735 362.32 322.895 342.652 323.35 308.176Z' fill='white' /%3E%3Cpath opacity='0.5' d='M195.715 200.816C172.923 186.007 161.527 165.183 161.527 136.954C180.672 111.503 213.493 96 253.835 96C323.35 96 363.692 133.252 373.721 185.776H310.359C303.293 165.183 285.971 148.986 254.291 148.986C220.33 148.986 197.311 169.116 195.715 200.816Z' fill='white' /%3E%3C/svg%3E%0A" />
-    <meta
-      name="generator"
-      content={Astro.generator}
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg width='512' height='512' viewBox='0 0 512 512' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='512' height='512' fill='%23F03E2F' rx='30' /%3E%3Cpath d='M161.527 136.723C161.527 179.76 187.738 205.443 240.388 219.095L296 232.283C345.687 243.852 376 272.775 376 319.514C376 341.727 369.162 360.931 357.538 375.971C357.538 329.232 333.607 303.78 276.171 288.74L221.47 276.246C177.709 266.065 143.977 242.464 143.977 191.56C143.977 170.505 150.359 151.994 161.527 136.723Z' fill='white' /%3E%3Cpath opacity='0.5' d='M323.35 308.176C347.054 323.679 357.538 345.197 357.538 376.202C337.709 401.654 303.293 416 262.724 416C194.575 416 146.484 381.756 136 322.753H201.641C210.074 350.056 232.41 362.551 262.268 362.551C298.735 362.32 322.895 342.652 323.35 308.176Z' fill='white' /%3E%3Cpath opacity='0.5' d='M195.715 200.816C172.923 186.007 161.527 165.183 161.527 136.954C180.672 111.503 213.493 96 253.835 96C323.35 96 363.692 133.252 373.721 185.776H310.359C303.293 165.183 285.971 148.986 254.291 148.986C220.33 148.986 197.311 169.116 195.715 200.816Z' fill='white' /%3E%3C/svg%3E%0A"
     />
+    <meta name="generator" content={Astro.generator} />
     <title>Sanity Studio</title>
     <style>
       body {
         margin: 0;
-        padding:0;
+        padding: 0;
       }
     </style>
   </head>

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
@@ -14,11 +14,7 @@ export function vitePluginSanityStudio(resolvedOptions, { output }): Plugin {
     },
     async load(id: string) {
       if (id === virtualModuleId) {
-        if (output !== "hybrid" && output !== "server") {
-          throw new Error(
-            "[@sanity/astro]: Sanity Studio requires `output: 'hybrid'` or `output: 'server'` in your Astro config",
-          );
-        }
+
         const studioConfig = await this.resolve("/sanity.config");
         if (!studioConfig) {
           throw new Error(


### PR DESCRIPTION
We unnecessarily require folks to set their Astro sites to `hybrid` or `server`. This PR adds a static path setting to the embedded studio route to eliminate the `prerender = false` declaration and thus, the need to set `output: 'hybrid'|'server'`.