### PR TITLE
refactor: improve internal types

### DIFF
--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -7,41 +7,35 @@ type IntegrationOptions = ClientConfig & {
   studioBasePath?: string;
 };
 
-const defaultOptions: IntegrationOptions = {
+const defaultClientConfig: ClientConfig = {
   apiVersion: "v2023-08-24",
 };
 
-export default function sanityIntegration(
-  options: IntegrationOptions,
-): AstroIntegration {
-  const resolvedOptions = {
-    ...defaultOptions,
-    ...options,
-  };
+export default function sanityIntegration({
+  studioBasePath,
+  ...clientConfig
+}: IntegrationOptions): AstroIntegration {
   return {
     name: "@sanity/astro",
     hooks: {
-      "astro:config:setup": ({
-        injectScript,
-        injectRoute,
-        updateConfig,
-        config,
-        logger,
-      }) => {
+      "astro:config:setup": ({ injectScript, injectRoute, updateConfig }) => {
         updateConfig({
           vite: {
             plugins: [
-              vitePluginSanityClient(resolvedOptions),
-              vitePluginSanityStudio(resolvedOptions, config),
+              vitePluginSanityClient({
+                ...defaultClientConfig,
+                ...clientConfig,
+              }),
+              vitePluginSanityStudio({ studioBasePath }),
             ],
           },
         });
         // only load this route if `studioBasePath` is set
-        if (resolvedOptions.studioBasePath) {
+        if (studioBasePath) {
           injectRoute({
             entryPoint: "@sanity/astro/studio/studio-route.astro", // Astro <= 3
             entrypoint: "@sanity/astro/studio/studio-route.astro", // Astro > 3
-            pattern: `/${resolvedOptions.studioBasePath}/[...params]`,
+            pattern: `/${studioBasePath}/[...params]`,
             prerender: false,
           });
         }

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.ts
@@ -1,10 +1,11 @@
 import type { ClientConfig } from "@sanity/client";
-import type { Plugin } from "vite";
+import type { DeepPartial } from "astro/dist/type-utils";
+import type { PluginOption } from "vite";
 
 const virtualModuleId = "sanity:client";
 const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
-export function vitePluginSanityClient(config: ClientConfig): Plugin {
+export function vitePluginSanityClient(config: ClientConfig) {
   return {
     name: "sanity:client",
     resolveId(id: string) {
@@ -22,5 +23,5 @@ export function vitePluginSanityClient(config: ClientConfig): Plugin {
         `;
       }
     },
-  };
+  } satisfies DeepPartial<PluginOption>;
 }

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
@@ -1,6 +1,9 @@
-import type { Plugin } from "vite";
+import type { DeepPartial } from "astro/dist/type-utils";
+import type { PluginOption } from "vite";
 
-export function vitePluginSanityStudio(resolvedOptions, { output }): Plugin {
+export function vitePluginSanityStudio(resolvedOptions: {
+  studioBasePath?: string;
+}) {
   const virtualModuleId = "sanity:studio";
   const resolvedVirtualModuleId = virtualModuleId;
 
@@ -44,5 +47,5 @@ export function vitePluginSanityStudio(resolvedOptions, { output }): Plugin {
       }
       return null;
     },
-  };
+  } satisfies DeepPartial<PluginOption>;
 }

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
@@ -19,7 +19,6 @@ export function vitePluginSanityStudio(resolvedOptions, { output }): Plugin {
           throw new Error(
             "[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root.",
           );
-          return null;
         }
         if (!resolvedOptions.studioBasePath) {
           throw new Error(


### PR DESCRIPTION
I had a little bit of trouble understanding what options/configs were passed
where and why, so now I've more clearly separated the client config options and
the `studioBasePath` option. I've also adjusted the return types of the Vite
Plugin factory functions to make TypeScript happy.