### PR TITLE
chore: .prettierignore CHANGLELOG.md

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -27,7 +27,7 @@ jobs:
           path: node_modules/.cache/prettier/.prettier-cache
           key: prettier-${{ hashFiles('package-lock.json') }}
       - run: npm run format
-      - run: git restore .github/workflows packages/*/CHANGELOG.md
+      - run: git restore .github/workflows
       - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-token
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
This way you don't accidentally format it if you run Prettier manually on the codebase.