### PR TITLE
fix: allow non-JSON ClientConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6045,6 +6045,12 @@
       "version": "0.16.3",
       "license": "MIT"
     },
+    "node_modules/@types/serialize-javascript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/serialize-javascript/-/serialize-javascript-5.0.4.tgz",
+      "integrity": "sha512-Z2R7UKFuNWCP8eoa2o9e5rkD3hmWxx/1L0CYz0k2BZzGh0PhEVMp9kfGiqEml/0IglwNERXZ2hwNzIrSz/KHTA==",
+      "dev": true
+    },
     "node_modules/@types/shallow-equals": {
       "version": "1.0.0",
       "license": "MIT"
@@ -16754,6 +16760,15 @@
         "performance-now": "^2.1.0"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "devOptional": true,
@@ -18681,6 +18696,15 @@
       "dependencies": {
         "no-case": "^2.2.0",
         "upper-case-first": "^1.1.2"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/server-destroy": {
@@ -21919,15 +21943,17 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.10.0",
+        "@sanity/client": "^6.4.12",
         "@sanity/ui": "^1.8.3",
         "sanity": "*"
       },
       "devDependencies": {
+        "@types/serialize-javascript": "^5.0.4",
         "astro": "^4.0.9",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rimraf": "^5.0.5",
+        "serialize-javascript": "^6.0.2",
         "vite": "^4.5.0",
         "vite-plugin-dts": "^3.7.0"
       },

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -40,10 +40,12 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/serialize-javascript": "^5.0.4",
     "astro": "^4.0.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
+    "serialize-javascript": "^6.0.2",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.7.0"
   },
@@ -60,7 +62,7 @@
     "sanity"
   ],
   "dependencies": {
-    "@sanity/client": "^6.10.0",
+    "@sanity/client": "^6.4.12",
     "@sanity/ui": "^1.8.3",
     "sanity": "*"
   },

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.ts
@@ -1,5 +1,6 @@
 import type { ClientConfig } from "@sanity/client";
 import type { DeepPartial } from "astro/dist/type-utils";
+import serialize from "serialize-javascript";
 import type { PluginOption } from "vite";
 
 const virtualModuleId = "sanity:client";
@@ -18,7 +19,7 @@ export function vitePluginSanityClient(config: ClientConfig) {
         return `
           import { createClient } from "@sanity/client";
           export const sanityClient = createClient(
-            ${JSON.stringify(config)}
+            ${serialize(config)}
           );
         `;
       }


### PR DESCRIPTION
Before this change, non-JSON ClientConfig like the `ResolveStudioUrl` you can pass to `stega.studioUrl` would be serialised away. Now, we use `serialize-javascript` to serialise the config into a superset of JSON that preserves functions.

Note: Installing the dependency automatically adjusted the version range of `dependency.@sanity/client` to match the one in `peerDependencies`.