### PR TITLE
feat: add VisualEditing component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5377,13 +5377,12 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.10.0.tgz",
-      "integrity": "sha512-TavtxGB6NWjro2BTGXSkzXNMKFZbS2il1ItV3IdRvO0luLqS31eIz37+5X4CmCC8hGFe6fDoCjnH/iJ81vKM7g==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.18.2.tgz",
+      "integrity": "sha512-2XXPyR5bHFdwi0e5j6z/TLsiZm5skIUsqtsx645rglzhTO6rLzDRwWMn+dsU6DPigf9/9M0i5IJM64eZa9EyZw==",
       "dependencies": {
-        "@sanity/eventsource": "^5.0.0",
-        "@vercel/stega": "0.1.0",
-        "get-it": "^8.4.4",
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.4.30",
         "rxjs": "^7.0.0"
       },
       "engines": {
@@ -5414,11 +5413,12 @@
       }
     },
     "node_modules/@sanity/eventsource": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
+      "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
       "dependencies": {
-        "@types/event-source-polyfill": "1.0.1",
-        "@types/eventsource": "1.1.11",
+        "@types/event-source-polyfill": "1.0.5",
+        "@types/eventsource": "1.1.15",
         "event-source-polyfill": "1.0.31",
         "eventsource": "2.0.2"
       }
@@ -5667,6 +5667,20 @@
         "prettier": "^3.2.5"
       }
     },
+    "node_modules/@sanity/preview-url-secret": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-1.6.13.tgz",
+      "integrity": "sha512-3ZAadWN0bKtoa5A0ZDTerjaBRbxUNpIWWKEl/FF5s6rH84+Hx5ugtqVt0hjzK8SnWwHiq5KQsPuB8T+lqFomGA==",
+      "dependencies": {
+        "@sanity/uuid": "3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.18.2"
+      }
+    },
     "node_modules/@sanity/schema": {
       "version": "3.16.7",
       "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.16.7.tgz",
@@ -5761,6 +5775,47 @@
       "peerDependencies": {
         "react": "^18",
         "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/@sanity/visual-editing": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing/-/visual-editing-1.8.21.tgz",
+      "integrity": "sha512-tX+BMRR6pCEnKItst8DlB5VAgV36vHNM8gM77ItyJCdV6HQNU9YSqiHlxtHb+duQYP41PvEk79/okBPu0pNexQ==",
+      "dependencies": {
+        "@sanity/preview-url-secret": "^1.6.13",
+        "@vercel/stega": "0.1.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-is": "18.3.1",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "valibot": "0.30.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">= 2",
+        "@sanity/client": "^6.18.2",
+        "@sveltejs/kit": ">= 2",
+        "next": ">= 13 || >=14.3.0-canary.0 <14.3.0",
+        "svelte": ">= 4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sanity/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -5931,12 +5986,14 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/event-source-polyfill": {
-      "version": "1.0.1",
-      "license": "MIT"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw=="
     },
     "node_modules/@types/eventsource": {
-      "version": "1.1.11",
-      "license": "MIT"
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -6308,9 +6365,9 @@
       }
     },
     "node_modules/@vercel/stega": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-0.1.0.tgz",
-      "integrity": "sha512-5b0PkOJsFBX5alChuIO3qpkt5vIZBevzLPhUQ1UP8UzVjL3F1VllnZxp/thfD8R5ol7D7WHkgZHIjdUBX4tDpQ=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-0.1.2.tgz",
+      "integrity": "sha512-P7mafQXjkrsoyTRppnt0N21udKS9wUmLXHRyP9saLXLHw32j/FgUJ3FscSWgvSqRs4cj7wKZtwqJEvWJ2jbGmA=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.0.4",
@@ -10645,14 +10702,15 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -10936,18 +10994,15 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.4.tgz",
-      "integrity": "sha512-Pu3pnJfnYuLEhwJgMlFqk19ugvtazzTxh7rg8wATaBL4c5Fy4ahM5B+bGdluiNSNYYK89F5vSa+N3sTa/qqtlg==",
+      "version": "8.4.30",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.30.tgz",
+      "integrity": "sha512-pd361r0zg6zEMobLZQ77VYHgfcC3WBkTwhgZE0+TOkIWMU9406ejVdROxt73fqMZW70w32qxbCi5nAlAwtqABw==",
       "dependencies": {
-        "debug": "^4.3.4",
         "decompress-response": "^7.0.0",
-        "follow-redirects": "^1.15.2",
+        "follow-redirects": "^1.15.6",
         "into-stream": "^6.0.0",
-        "is-plain-object": "^5.0.0",
         "is-retry-allowed": "^2.2.0",
         "is-stream": "^2.0.1",
-        "parse-headers": "^2.0.5",
         "progress-stream": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -16265,10 +16320,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "license": "MIT"
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "license": "MIT",
@@ -16898,8 +16949,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16929,14 +16981,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-fast-compare": {
@@ -16965,8 +17018,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "license": "MIT"
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -18758,8 +18812,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "license": "MIT",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -20985,6 +21040,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/valibot": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.30.0.tgz",
+      "integrity": "sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA=="
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "license": "Apache-2.0",
@@ -22159,6 +22219,7 @@
       "dependencies": {
         "@sanity/client": "^6.4.12",
         "@sanity/ui": "^1.8.3",
+        "@sanity/visual-editing": "^1.8.21",
         "sanity": "*"
       },
       "devDependencies": {

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -187,6 +187,37 @@ We recommend using [@sanity/image-url](https://www.sanity.io/docs/image-url) to 
 
 You can also use community-contributed integrations like [astro-sanity-picture][astro-sanity-picture] to integrate images from Sanity into your website.
 
+## Enabling Visual Editing
+
+To enable [Visual Editing][visual-editing], you should use `VisualEditing` from `@sanity/astro/visual-editing` in your ["page shell" layout](https://docs.astro.build/en/basics/layouts/):
+
+```ts
+---
+import {VisualEditing} from '@sanity/astro/visual-editing'
+
+export type props = {
+  title: string
+}
+const {title} = Astro.props
+const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED == 'true'
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+    <VisualEditing enabled={visualEditingEnabled} zIndex={1000} />
+    <!--                                          ^optional -->
+  </body>
+</html>
+```
+
 ### Resources
 
 - [The official Astro + Sanity guide][guide]
@@ -209,3 +240,4 @@ You can also use community-contributed integrations like [astro-sanity-picture][
 [sanity-client]: https://www.sanity.io/docs/js-client
 [image-urls]: https://www.sanity.io/docs/image-urls
 [vite-virtual-modules]: https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
+[visual-editing]: https://www.sanity.io/docs/introduction-to-visual-editing

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@sanity/client": "^6.4.12",
     "@sanity/ui": "^1.8.3",
+    "@sanity/visual-editing": "^1.8.21",
     "sanity": "*"
   },
   "publishConfig": {

--- a/packages/sanity-astro/src/visual-editing/index.ts
+++ b/packages/sanity-astro/src/visual-editing/index.ts
@@ -1,0 +1,1 @@
+export { default as VisualEditing } from "./visual-editing.astro";

--- a/packages/sanity-astro/src/visual-editing/visual-editing.astro
+++ b/packages/sanity-astro/src/visual-editing/visual-editing.astro
@@ -1,0 +1,57 @@
+---
+import type { VisualEditingOptions } from '@sanity/visual-editing'
+
+export interface Props extends Pick<VisualEditingOptions, 'zIndex'> {
+  enabled?: boolean
+}
+
+const {enabled, zIndex} = Astro.props
+---
+
+<sanity-astro-visual-editing enabled={enabled} data-z-index={zIndex}></sanity-astro-visual-editing>
+
+<script>
+  import {enableVisualEditing} from '@sanity/visual-editing'
+
+  class SanityAstroVisualEditing extends HTMLElement {
+    static observedAttributes = ['enabled']
+    private unsubscribe: (() => void) | null = null
+
+    constructor() {
+      super()
+    }
+
+    disconnectedCallback() {
+      this.teardownVisualEditing()
+    }
+
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+      if (name === 'enabled' && oldValue !== newValue) {
+        this.updateVisualEditing(newValue === 'true')
+      }
+    }
+
+    private updateVisualEditing(enabled: boolean) {
+      if (enabled) {
+        this.unsubscribe = enableVisualEditing({
+          zIndex: this.dataset.zIndex,
+          refresh: () => {
+            return new Promise((resolve) => {
+              window.location.reload()
+              resolve()
+            })
+          },
+        })
+      } else {
+        this.teardownVisualEditing()
+      }
+    }
+
+    private teardownVisualEditing() {
+      this.unsubscribe?.()
+      this.unsubscribe = null
+    }
+  }
+
+  customElements.define('sanity-astro-visual-editing', SanityAstroVisualEditing)
+</script>


### PR DESCRIPTION
This repo doesn't have an app to test this component with yet, but I've tested it in the `astro` app in `visual-editing` by

1. Building this package locally
2. `npm pack` to produce a tarball
3. Checking out this branch: https://github.com/sanity-io/visual-editing/pull/1545/files in `visual-editing`
4. Installing that `.tgz` file
   ```
   -    "@sanity/astro": "^3.0.1",
   +    "@sanity/astro": "file:../../../sanity-astro/packages/sanity-astro/sanity-astro-3.0.1.tgz",
   ```
5. Using `VisualEditing` from the pacakage
   ```
   -import {VisualEditing} from '@sanity/visual-editing/astro'
   +import {VisualEditing} from '@sanity/astro/visual-editing'  
   ```