### PR TITLE
fix(visual-editing): avoid using JSX in the .astro file

### DIFF
--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import {
+  VisualEditing as InternalVisualEditing,
+  type VisualEditingOptions as InternalVisualEditingOptions,
+} from '@sanity/visual-editing/react';
+
+export type VisualEditingOptions = Pick<InternalVisualEditingOptions, 'zIndex'>;
+
+export function VisualEditingComponent(props: VisualEditingOptions) {
+  return (
+    <InternalVisualEditing
+      zIndex={props.zIndex}
+      refresh={() => {
+        return new Promise((resolve) => {
+          window.location.reload();
+          resolve();
+        });
+      }}
+    />
+  );
+}

--- a/packages/sanity-astro/src/visual-editing/visual-editing.astro
+++ b/packages/sanity-astro/src/visual-editing/visual-editing.astro
@@ -1,16 +1,11 @@
 ---
-import { VisualEditing as InternalVisualEditing, type VisualEditingOptions } from '@sanity/visual-editing/react'
+import { VisualEditingComponent, type VisualEditingOptions } from './visual-editing-component'
 
-export interface Props extends Pick<VisualEditingOptions, 'zIndex'> {
+export interface Props extends VisualEditingOptions {
   enabled?: boolean
 }
 
 const {enabled, zIndex} = Astro.props
 ---
 
-{enabled ? <InternalVisualEditing client:load zIndex={zIndex} refresh={() => {
-  return new Promise((resolve) => {
-    window.location.reload()
-    resolve()
-  })
-}} /> : null}
+{enabled ? <VisualEditingComponent client:only="react" zIndex={zIndex} /> : null}


### PR DESCRIPTION
The previous code didn't work. You can't pass a callback to a React component that way in an `.astro` file. Therefore, we need an extra wrapper for this island.