### PR TITLE
docs: update manual installation dependency list

### DIFF
--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -25,7 +25,7 @@ Note: `@astrojs/react` is only needed if you plan to embed a Sanity Studio in yo
 ### Manual installation of dependencies
 
 ```bash
-npm install @astrojs/react @sanity/astro @types/react-dom @types/react react-dom react
+npm install @astrojs/react @sanity/astro @sanity/client @sanity/visual-editing sanity @types/react-dom @types/react react-dom react
 ```
 
 ### Adding types for `sanity:client`


### PR DESCRIPTION
`@sanity/client`, `@sanity/visual-editing` and `sanity` are now peer dependencies of this package.