### PR TITLE
chore: .prettierignore pnpm-lock.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 dist
 CHANGELOG.md
+pnpm-lock.yaml


### PR DESCRIPTION
Otherwise, Renovatebot will open a new Prettier PR every single time it has updated some dependencies.

---

I looked into if it was possible to add this ignore rule to https://github.com/sanity-io/prettier-config so it would apply to all our repos automatically, but it doesn't look like that is possible.