### PR TITLE
docs: prefix env var with PUBLIC_

### DIFF
--- a/apps/movies/src/env.d.ts
+++ b/apps/movies/src/env.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="@sanity/astro/module" />
 
 interface ImportMetaEnv {
-  readonly SANITY_VISUAL_EDITING_ENABLED: string
+  readonly PUBLIC_SANITY_VISUAL_EDITING_ENABLED: string
   readonly SANITY_API_READ_TOKEN: string
 }
 

--- a/apps/movies/src/layout.astro
+++ b/apps/movies/src/layout.astro
@@ -1,6 +1,6 @@
 ---
 import {VisualEditing} from '@sanity/astro/visual-editing'
-const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED == 'true'
+const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED == 'true'
 
 export type props = {
   title: string

--- a/apps/movies/src/load-query.ts
+++ b/apps/movies/src/load-query.ts
@@ -1,7 +1,7 @@
 import {type QueryParams} from 'sanity'
 import {sanityClient} from 'sanity:client'
 
-const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED === 'true'
+const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED === 'true'
 const token = import.meta.env.SANITY_API_READ_TOKEN
 
 export async function loadQuery<QueryResponse>({

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -227,7 +227,7 @@ export type props = {
   title: string
 }
 const {title} = Astro.props
-const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED == 'true'
+const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED == 'true'
 ---
 
 <html lang="en">
@@ -257,7 +257,7 @@ In the example above, `enabled` is controlled using an [environment variable](ht
 
 ```sh
 // .env.local
-SANITY_VISUAL_EDITING_ENABLED="true"
+PUBLIC_SANITY_VISUAL_EDITING_ENABLED="true"
 ```
 
 ### 2. Add the Presentation tool to the Studio
@@ -288,7 +288,7 @@ Now, all you need is a `loadQuery` helper function akin to this one:
 import {type QueryParams} from 'sanity'
 import {sanityClient} from 'sanity:client'
 
-const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED === 'true'
+const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED === 'true'
 const token = import.meta.env.SANITY_API_READ_TOKEN
 
 export async function loadQuery<QueryResponse>({


### PR DESCRIPTION
Hopefully, this avoids any confusion. The env var needs the `PUBLIC_` prefix to be used in the layout.