### PR TITLE
fix: remove wild semicolon in StudioComponent JSX

### DIFF
--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -21,7 +21,7 @@ export function StudioComponent() {
         overflow: 'hidden',
       }}
     >
-      <Studio config={config} />;
+      <Studio config={config} />
     </div>
   )
 }


### PR DESCRIPTION
The semicolon was added after the studio component, causing an issue with the positioning.

<img width="153" alt="Screenshot 2024-06-18 at 17 58 38" src="https://github.com/sanity-io/sanity-astro/assets/4224712/cda60cb7-3744-4660-b676-bbc3b4e0ec83">
