### PR TITLE
make studio base path optional

### DIFF
--- a/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
@@ -21,26 +21,13 @@ export function vitePluginSanityStudio(resolvedOptions: {studioBasePath?: string
             '[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root.',
           )
         }
-        if (!resolvedOptions.studioBasePath) {
-          throw new Error(
-            "[@sanity/astro]: The `studioBasePath` option is required in `astro.config.mjs`. For example — `studioBasePath: '/admin'`",
-          )
-        }
+        const studioBasePath = resolvedOptions.studioBasePath || ''
         return `
         import studioConfig from "${studioConfig.id}";
 
-        if (studioConfig.basePath) {
-          if (studioConfig.basePath !== "/${resolvedOptions.studioBasePath}") {
-            console.warn(
-              "[@sanity/astro]: This integration ignores the basePath setting in sanity.config.ts|js. To set the basePath for Sanity Studio, use the studioBasePath option in astro.config.mjs and remove it from sanity.config.ts.");
-          }
-        }
-
-        export const config = {
-          ...studioConfig,
-          // override basePath from sanity.config.ts|js with plugin setting
-          basePath: "${resolvedOptions.studioBasePath}",
-        }
+        if (studioConfig.basePath && studioConfig.basePath !== "${studioBasePath}") {
+          console.warn(
+            "[@sanity/astro]: The basePath setting in sanity.config.ts|js differs from the studioBasePath option in astro.config.mjs. The studioBasePath option will
         `
       }
       return null


### PR DESCRIPTION
Currently the integration crashes if you do not want to embed the Studio and don't supply `studioBasePath` in the `sanity()` integration.