### PR TITLE
 fix: ensure VisualEditing component renders outside body

### DIFF
--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -3,11 +3,12 @@ import {
   VisualEditing as InternalVisualEditing,
   type VisualEditingOptions as InternalVisualEditingOptions,
 } from '@sanity/visual-editing/react'
+import {createPortal} from 'react-dom'
 
 export type VisualEditingOptions = Pick<InternalVisualEditingOptions, 'zIndex'>
 
 export function VisualEditingComponent(props: VisualEditingOptions) {
-  return (
+  return createPortal(
     <InternalVisualEditing
       zIndex={props.zIndex}
       refresh={() => {
@@ -16,6 +17,7 @@ export function VisualEditingComponent(props: VisualEditingOptions) {
           resolve()
         })
       }}
-    />
+    />,
+    document.body.parentNode,
   )
 }


### PR DESCRIPTION
To enable Presentation's Drag and Drop minimap scaling, the `VisualEditing` component that wraps overlays/presentation-specific UI elements should render outside of the main body.