### PR TITLE
feat: support embedding studios without ssr

### DIFF
--- a/apps/example/astro.config.mjs
+++ b/apps/example/astro.config.mjs
@@ -1,6 +1,5 @@
 import sanity from '@sanity/astro'
 import {defineConfig} from 'astro/config'
-import vercel from '@astrojs/vercel'
 import react from '@astrojs/react'
 
 // https://astro.build/config
@@ -12,6 +11,10 @@ export default defineConfig({
       // If you are doing static builds you may want opt out of the CDN
       useCdn: false,
       studioBasePath: '/admin',
+      studioRouterHistory: 'hash',
+      stega: {
+        studioUrl: '/admin#',
+      },
     }),
     react(),
   ],
@@ -21,5 +24,4 @@ export default defineConfig({
       external: ['prismjs'],
     },
   },
-  adapter: vercel(),
 })

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -14,7 +14,6 @@
     "@astro-community/astro-embed-youtube": "^0.5.6",
     "@astrojs/prism": "^3.2.0",
     "@astrojs/react": "^4.2.0",
-    "@astrojs/vercel": "^8.0.4",
     "@sanity/astro": "workspace:^",
     "@sanity/client": "^6.27.2",
     "@sanity/image-url": "^1.1.0",

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -26,6 +26,7 @@
     },
     "./module": "./module.d.ts",
     "./studio/studio-route.astro": "./dist/studio/studio-route.astro",
+    "./studio/studio-route-hash.astro": "./dist/studio/studio-route-hash.astro",
     "./studio/studio-component.tsx": {
       "types": "./src/studio/studio-component.tsx",
       "default": "./src/studio/studio-component.tsx"
@@ -76,5 +77,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "history": "^5.3.0"
   }
 }

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -1,10 +1,12 @@
 import type {AstroIntegration} from 'astro'
 import {vitePluginSanityClient} from './vite-plugin-sanity-client'
 import {vitePluginSanityStudio} from './vite-plugin-sanity-studio'
+import {vitePluginSanityStudioHashRouter} from './vite-plugin-sanity-studio-hash-router'
 import type {ClientConfig} from '@sanity/client'
 
 type IntegrationOptions = ClientConfig & {
   studioBasePath?: string
+  studioRouterHistory?: 'browser' | 'hash'
 }
 
 const defaultClientConfig: ClientConfig = {
@@ -15,8 +17,10 @@ export default function sanityIntegration(
   integrationConfig: IntegrationOptions = {},
 ): AstroIntegration {
   const studioBasePath = integrationConfig.studioBasePath
+  const studioRouterHistory = integrationConfig.studioRouterHistory === 'hash' ? 'hash' : 'browser'
   const clientConfig = integrationConfig
   delete clientConfig.studioBasePath
+  delete clientConfig.studioRouterHistory
 
   if (!!studioBasePath && studioBasePath.match(/https?:\/\//)) {
     throw new Error(
@@ -36,18 +40,30 @@ export default function sanityIntegration(
                 ...clientConfig,
               }),
               vitePluginSanityStudio({studioBasePath}),
+              vitePluginSanityStudioHashRouter(),
             ],
           },
         })
         // only load this route if `studioBasePath` is set
         if (studioBasePath) {
-          injectRoute({
-            // @ts-expect-error
-            entryPoint: '@sanity/astro/studio/studio-route.astro', // Astro <= 3
-            entrypoint: '@sanity/astro/studio/studio-route.astro', // Astro > 3
-            pattern: `/${studioBasePath}/[...params]`,
-            prerender: false,
-          })
+          // If the studio router history is set to hash, we can load a studio route that doesn't need a server adapter
+          if (studioRouterHistory === 'hash') {
+            injectRoute({
+              // @ts-expect-error
+              entryPoint: '@sanity/astro/studio/studio-route-hash.astro', // Astro <= 3
+              entrypoint: '@sanity/astro/studio/studio-route-hash.astro', // Astro > 3
+              pattern: `/${studioBasePath}`,
+              prerender: true,
+            })
+          } else {
+            injectRoute({
+              // @ts-expect-error
+              entryPoint: '@sanity/astro/studio/studio-route.astro', // Astro <= 3
+              entrypoint: '@sanity/astro/studio/studio-route.astro', // Astro > 3
+              pattern: `/${studioBasePath}/[...params]`,
+              prerender: false,
+            })
+          }
         }
         injectScript(
           'page-ssr',

--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {createHashHistory, type History, type Listener} from 'history'
 // @ts-ignore
 import {config} from 'sanity:studio'
 import {Studio} from 'sanity'
@@ -9,7 +10,11 @@ if (!config) {
   )
 }
 
-export function StudioComponent() {
+export function StudioComponent(props: {history?: 'browser' | 'hash'}) {
+  const history = React.useMemo(
+    () => (props.history === 'hash' ? createHashHistoryForStudio() : undefined),
+    [props.history],
+  )
   return (
     <div
       data-ui="AstroStudioLayout"
@@ -21,7 +26,49 @@ export function StudioComponent() {
         overflow: 'hidden',
       }}
     >
-      <Studio config={config} />
+      <Studio config={config} unstable_history={history} />
     </div>
   )
+}
+
+function createHashHistoryForStudio(): History {
+  const history = createHashHistory()
+  return {
+    get action() {
+      return history.action
+    },
+    get location() {
+      return history.location
+    },
+    get createHref() {
+      return history.createHref
+    },
+    get push() {
+      return history.push
+    },
+    get replace() {
+      return history.replace
+    },
+    get go() {
+      return history.go
+    },
+    get back() {
+      return history.back
+    },
+    get forward() {
+      return history.forward
+    },
+    get block() {
+      return history.block
+    },
+    // Overriding listen to workaround a problem where native history provides history.listen(location => void), but the npm package is history.listen(({action, location}) => void)
+    listen(listener: Listener) {
+      // return history.listen(({ action, location }) => {
+      return history.listen(({location}) => {
+        // console.debug('history.listen', action, location)
+        // @ts-expect-error -- working around a bug? in studio
+        listener(location)
+      })
+    },
+  }
 }

--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -63,9 +63,7 @@ function createHashHistoryForStudio(): History {
     },
     // Overriding listen to workaround a problem where native history provides history.listen(location => void), but the npm package is history.listen(({action, location}) => void)
     listen(listener: Listener) {
-      // return history.listen(({ action, location }) => {
       return history.listen(({location}) => {
-        // console.debug('history.listen', action, location)
         // @ts-expect-error -- working around a bug? in studio
         listener(location)
       })

--- a/packages/sanity-astro/src/studio/studio-route-hash.astro
+++ b/packages/sanity-astro/src/studio/studio-route-hash.astro
@@ -1,0 +1,28 @@
+---
+import {StudioComponent} from './studio-component'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!--  Studio implements display cutouts CSS (The iPhone Notch ™ ) and needs `viewport-fit=cover` for it to work correctly -->
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg width='512' height='512' viewBox='0 0 512 512' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='512' height='512' fill='%23F03E2F' rx='30' /%3E%3Cpath d='M161.527 136.723C161.527 179.76 187.738 205.443 240.388 219.095L296 232.283C345.687 243.852 376 272.775 376 319.514C376 341.727 369.162 360.931 357.538 375.971C357.538 329.232 333.607 303.78 276.171 288.74L221.47 276.246C177.709 266.065 143.977 242.464 143.977 191.56C143.977 170.505 150.359 151.994 161.527 136.723Z' fill='white' /%3E%3Cpath opacity='0.5' d='M323.35 308.176C347.054 323.679 357.538 345.197 357.538 376.202C337.709 401.654 303.293 416 262.724 416C194.575 416 146.484 381.756 136 322.753H201.641C210.074 350.056 232.41 362.551 262.268 362.551C298.735 362.32 322.895 342.652 323.35 308.176Z' fill='white' /%3E%3Cpath opacity='0.5' d='M195.715 200.816C172.923 186.007 161.527 165.183 161.527 136.954C180.672 111.503 213.493 96 253.835 96C323.35 96 363.692 133.252 373.721 185.776H310.359C303.293 165.183 285.971 148.986 254.291 148.986C220.33 148.986 197.311 169.116 195.715 200.816Z' fill='white' /%3E%3C/svg%3E%0A"
+    />
+    <meta name="generator" content={Astro.generator} />
+    <title>Sanity Studio</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <StudioComponent client:only="react" history="hash" />
+  </body>
+</html>

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio-hash-router.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio-hash-router.ts
@@ -1,0 +1,30 @@
+import type {PartialDeep} from 'type-fest'
+import type {PluginOption} from 'vite'
+
+export function vitePluginSanityStudioHashRouter() {
+  const virtualModuleId = 'sanity:studio-hash-router'
+  const resolvedVirtualModuleId = virtualModuleId
+
+  return {
+    name: 'sanity:studio-hash-router',
+    resolveId(id: string) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId
+      }
+      return null
+    },
+    async load(id: string) {
+      if (id === virtualModuleId) {
+        const studioConfig = await this.resolve('/sanity.config')
+        if (!studioConfig) {
+          throw new Error(
+            '[@sanity/astro]: Sanity Studio requires a `sanity.config.ts|js` file in your project root.',
+          )
+        }
+
+        return `export {default} from "${studioConfig.id}";`
+      }
+      return null
+    },
+  } satisfies PartialDeep<PluginOption>
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@astrojs/react':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@22.10.10)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(yaml@2.7.0)
-      '@astrojs/vercel':
-        specifier: ^8.0.4
-        version: 8.0.4(astro@5.1.10(@types/node@22.10.10)(rollup@4.31.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(react@19.0.0)(rollup@4.31.0)
       '@sanity/astro':
         specifier: workspace:^
         version: link:../../packages/sanity-astro
@@ -176,6 +173,10 @@ importers:
         version: 5.7.3
 
   packages/sanity-astro:
+    dependencies:
+      history:
+        specifier: ^5.3.0
+        version: 5.3.0
     devDependencies:
       '@sanity/client':
         specifier: ^6.27.2
@@ -11234,7 +11235,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -11260,7 +11261,7 @@ snapshots:
     dependencies:
       debug: 4.4.0
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.10
@@ -11279,7 +11280,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8


### PR DESCRIPTION
Fixes #232, allows embedding a studio with a hash router, similar to the `next-sanity` feature:

```ts
// app/studio/page.tsx
import {NextStudio} from 'next-sanity'
import config from 'sanity.config'

export default function StudioPage() {
  return <NextStudio config={config} history="hash" />
}
```

If it works well it could be a good default in a future major.