### PR TITLE
fix: make visual editing a direct dependency

### DIFF
--- a/apps/movies/package.json
+++ b/apps/movies/package.json
@@ -16,7 +16,6 @@
     "@astrojs/vercel": "^8.0.7",
     "@sanity/astro": "workspace:^",
     "@sanity/client": "^6.28.0",
-    "@sanity/visual-editing": "^2.13.3",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "astro": "^5.3.0",

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -26,7 +26,7 @@ Note: `@astrojs/react` is only needed if you plan to embed a Sanity Studio in yo
 ### Manual installation of dependencies
 
 ```bash
-npm install @astrojs/react @sanity/astro @sanity/client @sanity/visual-editing sanity @types/react-dom @types/react react-dom react
+npm install @astrojs/react @sanity/astro @sanity/client sanity @types/react-dom @types/react react-dom react
 ```
 
 ### Adding types for `sanity:client`

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/astro",
-  "version": "3.2.2",
+  "version": "3.2.3-canary.4",
   "description": "Official Sanity Astro integration",
   "keywords": [
     "astro-integration",
@@ -52,11 +52,11 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
+    "@sanity/visual-editing": "^2.13.4",
     "history": "^5.3.0"
   },
   "devDependencies": {
     "@sanity/client": "^6.28.0",
-    "@sanity/visual-editing": "^2.13.4",
     "@types/serialize-javascript": "^5.0.4",
     "astro": "^5.3.0",
     "react": "^19.0.0",
@@ -69,10 +69,10 @@
   },
   "peerDependencies": {
     "@sanity/client": "^6.28.0",
-    "@sanity/visual-editing": "^2.13.4",
     "astro": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
     "react": "^18.2.0 || ^19.0.0",
     "react-dom": "^18.2.0 || ^19.0.0",
+    "react-is": "^18.2.0 || ^19.0.0",
     "sanity": "^3.75.1"
   },
   "engines": {

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -36,11 +36,10 @@ export default function sanityIntegration(
           vite: {
             optimizeDeps: {
               include: [
-                '@sanity/visual-editing > @sanity/ui > react-compiler-runtime',
-                '@sanity/visual-editing > styled-components > shallowequal',
-                '@sanity/visual-editing > react-is',
-                '@sanity/visual-editing > react-compiler-runtime',
-                '@sanity/visual-editing > lodash/startCase.js',
+                'react-compiler-runtime',
+                'react-is',
+                'styled-components',
+                'lodash/startCase.js',
               ],
             },
             plugins: [

--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -9,6 +9,7 @@ export type VisualEditingOptions = Pick<InternalVisualEditingOptions, 'zIndex'>
 export function VisualEditingComponent(props: VisualEditingOptions) {
   return (
     <InternalVisualEditing
+      portal
       zIndex={props.zIndex}
       refresh={() => {
         return new Promise((resolve) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,9 +144,6 @@ importers:
       '@sanity/client':
         specifier: ^6.28.0
         version: 6.28.0(debug@4.4.0)
-      '@sanity/visual-editing':
-        specifier: ^2.13.3
-        version: 2.13.4(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.28.0)(@sanity/types@3.75.1(@types/react@19.0.10))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10
@@ -174,16 +171,19 @@ importers:
 
   packages/sanity-astro:
     dependencies:
+      '@sanity/visual-editing':
+        specifier: ^2.13.4
+        version: 2.13.4(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.28.0)(@sanity/types@3.75.1(@types/react@19.0.10))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
       history:
         specifier: ^5.3.0
         version: 5.3.0
+      react-is:
+        specifier: ^18.2.0 || ^19.0.0
+        version: 18.3.1
     devDependencies:
       '@sanity/client':
         specifier: ^6.28.0
         version: 6.28.0(debug@4.4.0)
-      '@sanity/visual-editing':
-        specifier: ^2.13.4
-        version: 2.13.4(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.28.0)(@sanity/types@3.75.1(@types/react@19.0.10))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
@@ -11154,7 +11154,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -11180,7 +11180,7 @@ snapshots:
     dependencies:
       debug: 4.4.0
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.10
@@ -11199,7 +11199,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8


### PR DESCRIPTION
The fix in #301 proved to be too reliant on package manager behavior for the `optimizeDeps` to "take". By moving `@sanity/visual-editing` from a peer dep to a direct one, the `optimizeDeps.include` rules consistently apply in pnpm v9+, npm v10+ and yarn v4+.

Adding `react-is` to peer deps also ensures the `npx astro add` command picks it up, and solves warnings in yarn v4.

Finally, the `portal` prop added to `<InternalVisualEditing>` fixes a TS error there. `portal={true}` is the default value under the hood.