### PR TITLE
wip: 2150 testing

### DIFF
--- a/apps/example-ssr/sanity.config.ts
+++ b/apps/example-ssr/sanity.config.ts
@@ -1,17 +1,45 @@
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
+import {presentationTool} from 'sanity/presentation'
 import {schemaTypes} from './schemas'
 
 export const projectId = import.meta.env.PUBLIC_SANITY_PROJECT_ID! || '3do82whm'
 export const dataset = import.meta.env.PUBLIC_SANITY_DATASET! || 'next'
+
+const branchUrl =
+  (import.meta.env?.['VERCEL_BRANCH_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_BRANCH_URL : undefined)
+const deployUrl =
+  (import.meta.env?.['VERCEL_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_URL : undefined)
+const productionUrl =
+  (import.meta.env?.['VERCEL_PROJECT_PRODUCTION_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_PROJECT_PRODUCTION_URL : undefined)
+
+const previewUrlInitial = branchUrl
+  ? `https://${branchUrl}`
+  : deployUrl
+    ? `https://${deployUrl}`
+    : productionUrl
+      ? `https://${productionUrl}`
+      : 'http://localhost:4321'
 
 export default defineConfig({
   name: 'project-name',
   title: 'Project Name',
   projectId,
   dataset,
-  plugins: [deskTool(), visionTool()],
+  plugins: [
+    deskTool(),
+    visionTool(),
+    presentationTool({
+      previewUrl: {
+        initial: previewUrlInitial,
+        preview: '/',
+      },
+    }),
+  ],
   schema: {
     types: schemaTypes,
   },

--- a/apps/example/sanity.config.ts
+++ b/apps/example/sanity.config.ts
@@ -1,6 +1,7 @@
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
+import {presentationTool} from 'sanity/presentation'
 import {sanityClient} from 'sanity:client'
 import {schemaTypes} from './schemas'
 
@@ -8,6 +9,25 @@ const {projectId, dataset} = sanityClient.config()
 if (!projectId || !dataset) {
   throw new Error('Missing projectId or dataset')
 }
+
+const branchUrl =
+  (import.meta.env?.['VERCEL_BRANCH_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_BRANCH_URL : undefined)
+const deployUrl =
+  (import.meta.env?.['VERCEL_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_URL : undefined)
+const productionUrl =
+  (import.meta.env?.['VERCEL_PROJECT_PRODUCTION_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_PROJECT_PRODUCTION_URL : undefined)
+
+const previewUrlInitial = branchUrl
+  ? `https://${branchUrl}`
+  : deployUrl
+    ? `https://${deployUrl}`
+    : productionUrl
+      ? `https://${productionUrl}`
+      : 'http://localhost:4321'
+
 console.log('projectId', projectId)
 export default defineConfig([
   {
@@ -16,7 +36,16 @@ export default defineConfig([
     basePath: '/workspace-1',
     projectId,
     dataset,
-    plugins: [deskTool(), visionTool()],
+    plugins: [
+      deskTool(),
+      visionTool(),
+      presentationTool({
+        previewUrl: {
+          initial: previewUrlInitial,
+          preview: '/',
+        },
+      }),
+    ],
     schema: {
       types: schemaTypes,
     },
@@ -27,7 +56,16 @@ export default defineConfig([
     basePath: '/workspace-2',
     projectId,
     dataset,
-    plugins: [deskTool(), visionTool()],
+    plugins: [
+      deskTool(),
+      visionTool(),
+      presentationTool({
+        previewUrl: {
+          initial: previewUrlInitial,
+          preview: '/',
+        },
+      }),
+    ],
     schema: {
       types: schemaTypes,
     },

--- a/apps/movies/sanity.config.ts
+++ b/apps/movies/sanity.config.ts
@@ -6,6 +6,9 @@ import {defineDocuments, defineLocations, presentationTool} from 'sanity/present
 const branchUrl =
   (import.meta.env?.['VERCEL_BRANCH_URL'] as string | undefined) ??
   (typeof process !== 'undefined' ? process.env.VERCEL_BRANCH_URL : undefined)
+const deployUrl =
+  (import.meta.env?.['VERCEL_URL'] as string | undefined) ??
+  (typeof process !== 'undefined' ? process.env.VERCEL_URL : undefined)
 const productionUrl =
   (import.meta.env?.['VERCEL_PROJECT_PRODUCTION_URL'] as string | undefined) ??
   (typeof process !== 'undefined' ? process.env.VERCEL_PROJECT_PRODUCTION_URL : undefined)
@@ -41,6 +44,8 @@ export default defineConfig({
       previewUrl: {
         initial: branchUrl
           ? `https://${branchUrl}`
+          : deployUrl
+            ? `https://${deployUrl}`
           : productionUrl
             ? `https://${productionUrl}`
             : 'http://localhost:4321',

--- a/apps/movies/sanity.config.ts
+++ b/apps/movies/sanity.config.ts
@@ -12,6 +12,13 @@ const deployUrl =
 const productionUrl =
   (import.meta.env?.['VERCEL_PROJECT_PRODUCTION_URL'] as string | undefined) ??
   (typeof process !== 'undefined' ? process.env.VERCEL_PROJECT_PRODUCTION_URL : undefined)
+const configuredPreviewOrigin = branchUrl
+  ? `https://${branchUrl}`
+  : deployUrl
+    ? `https://${deployUrl}`
+    : productionUrl
+      ? `https://${productionUrl}`
+      : undefined
 
 const locations = {
   movie: defineLocations({
@@ -42,13 +49,7 @@ export default defineConfig({
   plugins: [
     presentationTool({
       previewUrl: {
-        initial: branchUrl
-          ? `https://${branchUrl}`
-          : deployUrl
-            ? `https://${deployUrl}`
-          : productionUrl
-            ? `https://${productionUrl}`
-            : 'http://localhost:4321',
+        initial: async ({origin}) => configuredPreviewOrigin ?? origin,
         preview: '/',
       },
       resolve: {

--- a/apps/movies/sanity/components/custom-input.tsx
+++ b/apps/movies/sanity/components/custom-input.tsx
@@ -1,0 +1,11 @@
+import type {StringInputProps} from 'sanity'
+
+export function CustomInput(props: StringInputProps) {
+  console.log(props)
+  return (
+    <>
+      <button onClick={() => alert('Hello')}>Click me</button>
+      {props.renderDefault(props)}
+    </>
+  )
+}

--- a/apps/movies/schemaTypes/movie.ts
+++ b/apps/movies/schemaTypes/movie.ts
@@ -1,5 +1,6 @@
-import {defineField, defineType} from 'sanity'
-import {MdLocalMovies as icon} from 'react-icons/md'
+import { defineField, defineType } from 'sanity'
+import { MdLocalMovies as icon } from 'react-icons/md'
+import { CustomInput } from '../sanity/components/custom-input'
 
 export default defineType({
   name: 'movie',
@@ -11,6 +12,9 @@ export default defineType({
       name: 'title',
       title: 'Title',
       type: 'string',
+      components: {
+        input: CustomInput,
+      },
     }),
     defineField({
       name: 'slug',
@@ -53,13 +57,13 @@ export default defineType({
       name: 'castMembers',
       title: 'Cast Members',
       type: 'array',
-      of: [{type: 'castMember'}],
+      of: [{ type: 'castMember' }],
     }),
     defineField({
       name: 'crewMembers',
       title: 'Crew Members',
       type: 'array',
-      of: [{type: 'crewMember'}],
+      of: [{ type: 'crewMember' }],
     }),
   ],
   preview: {

--- a/packages/sanity-astro/src/studio/studio-route.astro
+++ b/packages/sanity-astro/src/studio/studio-route.astro
@@ -1,9 +1,5 @@
 ---
 import {StudioComponent} from './studio-component'
-// Astro will warn about this being ignore, but it has to be there.
-export async function getStaticPaths() {
-  return [{params: {path: 'admin'}}]
-}
 // This route needs to run in "SPA" mode, so we need to set `prerender` to `false`
 export const prerender = false
 ---


### PR DESCRIPTION
This pull request introduces several improvements to the Sanity Studio configuration across multiple example apps, focusing on enhancing preview URL handling for Vercel deployments and adding a custom input component in the movies app. The changes improve environment adaptability, developer experience, and UI extensibility.

**Sanity Studio Preview URL Improvements:**

* Added logic to determine the appropriate preview URL (`previewUrlInitial`) by checking `VERCEL_BRANCH_URL`, `VERCEL_URL`, and `VERCEL_PROJECT_PRODUCTION_URL` environment variables, with a fallback to localhost, in `sanity.config.ts` for the `example-ssr`, `example`, and `movies` apps. This ensures the correct preview URL is used in different Vercel deployment scenarios. [[1]](diffhunk://#diff-7de44949564702a4e41a06a38f15186ec1fb41ce4ac7dd7e253efb568e42a503R4-R42) [[2]](diffhunk://#diff-84f04cb3a3fe79fa251970f77c079c68acb6cfb795debcd02a10eda27ae9434aR4-R30) [[3]](diffhunk://#diff-c62970b6ec6bd7c00a0dfcbdbc855f9984b8bc799b4f8c6c279757897dca4555R9-R11) [[4]](diffhunk://#diff-c62970b6ec6bd7c00a0dfcbdbc855f9984b8bc799b4f8c6c279757897dca4555R47-R48)
* Integrated the `presentationTool` plugin into the Sanity Studio configuration for all example apps, utilizing the dynamically determined preview URL for improved content previewing. [[1]](diffhunk://#diff-7de44949564702a4e41a06a38f15186ec1fb41ce4ac7dd7e253efb568e42a503R4-R42) [[2]](diffhunk://#diff-84f04cb3a3fe79fa251970f77c079c68acb6cfb795debcd02a10eda27ae9434aL19-R48) [[3]](diffhunk://#diff-84f04cb3a3fe79fa251970f77c079c68acb6cfb795debcd02a10eda27ae9434aL30-R68)

**Custom Input Component in Movies App:**

* Added a new `CustomInput` React component in `custom-input.tsx`, which renders a button and the default input, and logs the input props for debugging.
* Registered the `CustomInput` component as a custom input for the `title` field in the `movie` schema, allowing for UI customization and demonstration of extending Sanity Studio input components. [[1]](diffhunk://#diff-a09015bee20e18f7fddb6239acff5fdfcb0dda392ecc7ad035780a3588194842R3) [[2]](diffhunk://#diff-a09015bee20e18f7fddb6239acff5fdfcb0dda392ecc7ad035780a3588194842R15-R17)

**Other Improvements:**

* Removed unused `getStaticPaths` export from the Astro studio route to clean up warnings and ensure correct SPA mode operation.