### PR TITLE
feat: Add studio chunk-size warning plugin and tests

### DIFF
--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -2,6 +2,7 @@ import type {AstroIntegration} from 'astro'
 import {vitePluginSanityClient} from './vite-plugin-sanity-client'
 import {vitePluginSanityStudio} from './vite-plugin-sanity-studio'
 import {vitePluginSanityStudioHashRouter} from './vite-plugin-sanity-studio-hash-router'
+import {vitePluginSanityStudioChunkWarning} from './vite-plugin-sanity-studio-chunk-warning'
 import type {ClientConfig} from '@sanity/client'
 import {normalizeStudioBasePath, studioRoutePattern} from './studio-base-path'
 
@@ -54,6 +55,7 @@ export default function sanityIntegration(
                 studioRouterHistory,
               }),
               vitePluginSanityStudioHashRouter(),
+              vitePluginSanityStudioChunkWarning(),
             ],
           },
         })

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.test.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, it} from 'vitest'
+import {
+  collectStudioChunkFiles,
+  getOversizedNonStudioChunks,
+  isStudioChunkRoot,
+} from './vite-plugin-sanity-studio-chunk-warning'
+
+describe('studio chunk size warning filter', () => {
+  it('identifies Studio root chunks', () => {
+    expect(
+      isStudioChunkRoot({
+        fileName: 'assets/studio-component.abcd1234.js',
+      }),
+    ).toBe(true)
+  })
+
+  it('does not identify non-Studio root chunks', () => {
+    expect(
+      isStudioChunkRoot({
+        fileName: 'assets/app-client.abcd1234.js',
+      }),
+    ).toBe(false)
+  })
+
+  it('collects the full Studio import graph from root chunk(s)', () => {
+    const chunksByFileName = new Map([
+      [
+        'assets/studio-component.abcd1234.js',
+        {
+          fileName: 'assets/studio-component.abcd1234.js',
+          imports: ['assets/studio-shared.abcd1234.js'],
+        },
+      ],
+      [
+        'assets/studio-shared.abcd1234.js',
+        {
+          fileName: 'assets/studio-shared.abcd1234.js',
+          imports: [],
+          dynamicImports: ['assets/studio-video.abcd1234.js'],
+        },
+      ],
+      [
+        'assets/studio-video.abcd1234.js',
+        {
+          fileName: 'assets/studio-video.abcd1234.js',
+        },
+      ],
+      [
+        'assets/app-client.abcd1234.js',
+        {
+          fileName: 'assets/app-client.abcd1234.js',
+          imports: [],
+        },
+      ],
+    ])
+
+    const studioChunkFiles = collectStudioChunkFiles(chunksByFileName)
+    expect(studioChunkFiles).toEqual(
+      new Set([
+        'assets/studio-component.abcd1234.js',
+        'assets/studio-shared.abcd1234.js',
+        'assets/studio-video.abcd1234.js',
+      ]),
+    )
+  })
+
+  it('flags only oversized non-Studio chunks', () => {
+    const chunksByFileName = new Map([
+      [
+        'assets/studio-component.abcd1234.js',
+        {
+          fileName: 'assets/studio-component.abcd1234.js',
+          code: 'x'.repeat(1024 * 1200),
+          imports: ['assets/studio-video.abcd1234.js'],
+        },
+      ],
+      [
+        'assets/studio-video.abcd1234.js',
+        {
+          fileName: 'assets/studio-video.abcd1234.js',
+          code: 'x'.repeat(1024 * 1300),
+        },
+      ],
+      [
+        'assets/app-large.abcd1234.js',
+        {
+          fileName: 'assets/app-large.abcd1234.js',
+          code: 'x'.repeat(1024 * 900),
+        },
+      ],
+      [
+        'assets/app-small.abcd1234.js',
+        {
+          fileName: 'assets/app-small.abcd1234.js',
+          code: 'x'.repeat(1024 * 100),
+        },
+      ],
+    ])
+
+    const oversizedNonStudioChunks = getOversizedNonStudioChunks(chunksByFileName, 500)
+    expect(oversizedNonStudioChunks).toEqual(['assets/app-large.abcd1234.js'])
+  })
+})

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.ts
@@ -1,0 +1,142 @@
+import type {PluginOption, UserConfig} from 'vite'
+
+const DEFAULT_CHUNK_SIZE_WARNING_LIMIT = 500
+
+const STUDIO_CHUNK_PATTERNS = [
+  'studio-component',
+  '@sanity/astro/studio',
+  'sanity:studio',
+  'studio-route',
+]
+
+type ChunkLike = {
+  name?: string
+  fileName: string
+  facadeModuleId?: string | null
+  moduleIds?: string[]
+  imports?: string[]
+  dynamicImports?: string[]
+  code?: string
+}
+
+function includesStudioChunkPattern(text: string): boolean {
+  const lowerText = text.toLowerCase()
+  return STUDIO_CHUNK_PATTERNS.some((pattern) => lowerText.includes(pattern))
+}
+
+export function isStudioChunkRoot(chunk: ChunkLike): boolean {
+  const chunkFields = [chunk.name, chunk.fileName, chunk.facadeModuleId, ...(chunk.moduleIds ?? [])]
+  const chunkText = chunkFields
+    .filter((field): field is string => typeof field === 'string')
+    .join(' ')
+  return includesStudioChunkPattern(chunkText)
+}
+
+export function collectStudioChunkFiles(chunksByFileName: Map<string, ChunkLike>): Set<string> {
+  const studioChunkFiles = new Set<string>()
+  const toVisit: string[] = []
+
+  for (const chunk of chunksByFileName.values()) {
+    if (isStudioChunkRoot(chunk)) {
+      toVisit.push(chunk.fileName)
+    }
+  }
+
+  while (toVisit.length > 0) {
+    const nextFileName = toVisit.pop()
+    if (!nextFileName || studioChunkFiles.has(nextFileName)) {
+      continue
+    }
+
+    studioChunkFiles.add(nextFileName)
+    const chunk = chunksByFileName.get(nextFileName)
+    if (!chunk) {
+      continue
+    }
+
+    for (const importedChunk of [...(chunk.imports ?? []), ...(chunk.dynamicImports ?? [])]) {
+      if (chunksByFileName.has(importedChunk) && !studioChunkFiles.has(importedChunk)) {
+        toVisit.push(importedChunk)
+      }
+    }
+  }
+
+  return studioChunkFiles
+}
+
+export function formatLargeChunkWarning(limitInKb: number, oversizedChunkFileNames: string[]): string {
+  const chunkList = oversizedChunkFileNames.map((fileName) => `- ${fileName}`).join('\n')
+  return `Some chunks are larger than ${limitInKb} kB after minification. Consider:
+${chunkList}
+- Using dynamic import() to code-split the application
+- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
+- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.`
+}
+
+export function getOversizedNonStudioChunks(
+  chunksByFileName: Map<string, ChunkLike>,
+  chunkSizeWarningLimitInKb: number,
+): string[] {
+  const studioChunkFiles = collectStudioChunkFiles(chunksByFileName)
+  const oversizedNonStudioChunks: string[] = []
+
+  for (const chunk of chunksByFileName.values()) {
+    if (studioChunkFiles.has(chunk.fileName)) {
+      continue
+    }
+    const chunkCode = chunk.code ?? ''
+    const chunkSizeInKb = Buffer.byteLength(chunkCode, 'utf8') / 1024
+    if (chunkSizeInKb > chunkSizeWarningLimitInKb) {
+      oversizedNonStudioChunks.push(chunk.fileName)
+    }
+  }
+
+  return oversizedNonStudioChunks
+}
+
+export function vitePluginSanityStudioChunkWarning(): PluginOption {
+  let chunkSizeWarningLimitInKb = DEFAULT_CHUNK_SIZE_WARNING_LIMIT
+
+  return {
+    name: 'vite-plugin-sanity-studio-chunk-warning',
+    apply: 'build',
+    config(config: UserConfig) {
+      if (typeof config.build?.chunkSizeWarningLimit === 'number') {
+        chunkSizeWarningLimitInKb = config.build.chunkSizeWarningLimit
+      }
+
+      return {
+        build: {
+          chunkSizeWarningLimit: Number.MAX_SAFE_INTEGER,
+        },
+      }
+    },
+    generateBundle(_, bundle) {
+      const chunksByFileName = new Map<string, ChunkLike>()
+      for (const output of Object.values(bundle)) {
+        if (output.type !== 'chunk') {
+          continue
+        }
+
+        chunksByFileName.set(output.fileName, {
+          name: output.name,
+          fileName: output.fileName,
+          facadeModuleId: output.facadeModuleId,
+          moduleIds: Object.keys(output.modules),
+          imports: output.imports,
+          dynamicImports: output.dynamicImports,
+          code: output.code,
+        })
+      }
+
+      const oversizedNonStudioChunks = getOversizedNonStudioChunks(
+        chunksByFileName,
+        chunkSizeWarningLimitInKb,
+      )
+
+      if (oversizedNonStudioChunks.length > 0) {
+        this.warn(formatLargeChunkWarning(chunkSizeWarningLimitInKb, oversizedNonStudioChunks))
+      }
+    },
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Vite plugin to the `sanity-astro` integration that warns about oversized non-Studio JavaScript chunks during the build process. The plugin ensures that only non-Studio chunks exceeding a configurable size threshold trigger warnings, helping developers optimize bundle sizes without being distracted by large Studio-related chunks. The implementation includes comprehensive unit tests for the plugin's core logic.

**New Vite plugin for chunk size warnings:**

* Added `vite-plugin-sanity-studio-chunk-warning.ts`, which defines a Vite plugin that:
  * Identifies Studio-related chunks by matching specific patterns in chunk names and dependencies.
  * Traverses the Studio chunk import graph to exclude all Studio chunks from size warnings.
  * Flags only non-Studio chunks that exceed the configured size limit (default 500kB).
  * Displays actionable warnings with suggestions for code-splitting and chunking improvements.

**Integration and configuration:**

* Registered the new plugin in the Astro integration pipeline by adding `vitePluginSanityStudioChunkWarning()` to the Vite plugins array in `index.ts`. [[1]](diffhunk://#diff-eefdcca2e8f43f60906f90f4e07c1ec244a0eba5e4b722f75fa5b93cc0d28527R5) [[2]](diffhunk://#diff-eefdcca2e8f43f60906f90f4e07c1ec244a0eba5e4b722f75fa5b93cc0d28527R58)

**Testing:**

* Added `vite-plugin-sanity-studio-chunk-warning.test.ts` with unit tests covering Studio chunk identification, import graph traversal, and the filtering of oversized non-Studio chunks.

Should solve #290 