### PR TITLE
feat: Add server-side logging for Sanity client

### DIFF
--- a/apps/example/astro.config.mjs
+++ b/apps/example/astro.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig({
       stega: {
         studioUrl: '/admin#',
       },
+      logClientRequests: 'always',
     }),
     react(),
   ],

--- a/apps/movies/astro.config.mjs
+++ b/apps/movies/astro.config.mjs
@@ -12,6 +12,8 @@ export default defineConfig({
       dataset: 'production',
       useCdn: true,
       studioBasePath: '/admin',
+      logClientRequests: 'dev',
+
       stega: {
         studioUrl: {
           baseUrl: '/admin',

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -58,6 +58,9 @@ export default defineConfig({
       dataset: '<YOUR-DATASET-NAME>',
       // Set useCdn to false if you're building statically.
       useCdn: false,
+      // Optional: log server-side Sanity client requests.
+      // Modes: 'dev' | 'build' | 'always'
+      logClientRequests: 'dev',
     }),
   ],
 })
@@ -86,6 +89,14 @@ const posts = await sanityClient.fetch(`*[_type == "post" && defined(slug)] | or
 ```
 
 [Check out this guide][guide] for a more elaborate introduction to how to integrate content from Sanity into Astro. You can also look in the `examples` folder in this repository for complete implementation examples.
+
+To log server-side requests made with `sanity:client`, set `logClientRequests` in your integration config:
+
+- `logClientRequests: 'dev'` logs during development
+- `logClientRequests: 'build'` logs during static builds
+- `logClientRequests: 'always'` logs during both development and builds
+
+If omitted, request logging is disabled.
 
 ### Embedding Sanity Studio on a route
 

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -8,6 +8,7 @@ import {normalizeStudioBasePath, studioRoutePattern} from './studio-base-path'
 type IntegrationOptions = ClientConfig & {
   studioBasePath?: string
   studioRouterHistory?: 'browser' | 'hash'
+  logClientRequests?: 'dev' | 'build' | 'always'
 }
 
 const defaultClientConfig: ClientConfig = {
@@ -20,9 +21,11 @@ export default function sanityIntegration(
   const studioBasePath = integrationConfig.studioBasePath
   const normalizedStudioBasePath = normalizeStudioBasePath(studioBasePath)
   const studioRouterHistory = integrationConfig.studioRouterHistory === 'hash' ? 'hash' : 'browser'
+  const logClientRequests = integrationConfig.logClientRequests
   const clientConfig = integrationConfig
   delete clientConfig.studioBasePath
   delete clientConfig.studioRouterHistory
+  delete clientConfig.logClientRequests
 
   if (!!studioBasePath && studioBasePath.match(/https?:\/\//)) {
     throw new Error(
@@ -48,7 +51,7 @@ export default function sanityIntegration(
               vitePluginSanityClient({
                 ...defaultClientConfig,
                 ...clientConfig,
-              }),
+              }, {logClientRequests}),
               vitePluginSanityStudio({
                 studioBasePath: normalizedStudioBasePath,
                 studioRouterHistory,

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.test.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.test.ts
@@ -77,19 +77,42 @@ describe('vitePluginSanityClient request logging wrappers', () => {
       createClient,
     })
 
-    const query = `*[_type == "movie"][0]`
-    const params = {slug: 'alien'}
-    const result = await (sanityClient.fetch as (q: string, p: Record<string, string>) => Promise<unknown>)(
-      query,
-      params,
-    )
+    class ErrorWithSourceStack extends Error {
+      stack: string
 
-    expect(result).toEqual({title: 'Alien'})
-    expect(fetchImpl).toHaveBeenCalledWith(query, params)
-    expect(infoSpy).toHaveBeenCalledTimes(1)
-    expect(String(infoSpy.mock.calls[0]?.[1])).toContain('query:')
-    expect(String(infoSpy.mock.calls[0]?.[1])).toContain('params:')
-    expect(String(infoSpy.mock.calls[0]?.[1])).toContain('"slug":"alien"')
+      constructor(message?: string) {
+        super(message)
+        this.stack = [
+          'Error',
+          '    at sanityClient.fetch (virtual-module.js:1:1)',
+          '    at loadQuery (/Users/chrislarocque/Documents/GitHub/sanity-astro/apps/movies/src/load-query.ts:22:9)',
+          '    at /Users/chrislarocque/Documents/GitHub/sanity-astro/apps/movies/src/pages/index.astro:10:3',
+        ].join('\n')
+      }
+    }
+
+    vi.stubGlobal('Error', ErrorWithSourceStack)
+
+    try {
+      const query = `*[_type == "movie"][0]`
+      const params = {slug: 'alien'}
+      const result = await (sanityClient.fetch as (
+        q: string,
+        p: Record<string, string>,
+        options: {filterResponse: boolean},
+      ) => Promise<unknown>)(query, params, {filterResponse: false})
+
+      expect(result).toEqual({title: 'Alien'})
+      expect(fetchImpl).toHaveBeenCalledWith(query, params, {filterResponse: false})
+      expect(infoSpy).toHaveBeenCalledTimes(1)
+      expect(String(infoSpy.mock.calls[0]?.[1])).toContain('query:')
+      expect(String(infoSpy.mock.calls[0]?.[1])).toContain('params:')
+      expect(String(infoSpy.mock.calls[0]?.[1])).toContain('source:')
+      expect(String(infoSpy.mock.calls[0]?.[1])).toContain('apps/movies/src/pages/index.astro')
+      expect(String(infoSpy.mock.calls[0]?.[1])).toContain('"slug":"alien"')
+    } finally {
+      vi.unstubAllGlobals()
+    }
 
     infoSpy.mockRestore()
   })

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.test.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.test.ts
@@ -1,0 +1,143 @@
+import {describe, expect, it, vi} from 'vitest'
+import {vitePluginSanityClient} from './vite-plugin-sanity-client'
+import type {ClientConfig} from '@sanity/client'
+
+type LogMode = 'dev' | 'build' | 'always' | undefined
+
+function buildVirtualClientModule({
+  logClientRequests,
+  env,
+  createClient,
+}: {
+  logClientRequests: LogMode
+  env: {DEV: boolean; PROD: boolean}
+  createClient: (config: ClientConfig) => Record<string, unknown>
+}) {
+  const plugin = vitePluginSanityClient(
+    {projectId: 'project-id', dataset: 'production', apiVersion: 'v2023-08-24'},
+    {logClientRequests},
+  )
+  const pluginHooks = plugin as unknown as {
+    resolveId?: (id: string) => string | undefined
+    load?: (id: string) => string | undefined
+  }
+
+  const resolvedId = pluginHooks.resolveId?.('sanity:client')
+  if (!resolvedId) {
+    throw new Error('Expected sanity:client module to resolve')
+  }
+
+  const source = pluginHooks.load?.(resolvedId)
+  if (typeof source !== 'string') {
+    throw new Error('Expected sanity:client virtual module source')
+  }
+
+  const executableSource = source
+    .replace('import { createClient } from "@sanity/client";', 'const {createClient} = __deps;')
+    .replace(/import\.meta\.env\.DEV/g, '__deps.importMeta.env.DEV')
+    .replace(/import\.meta\.env\.PROD/g, '__deps.importMeta.env.PROD')
+    .replace('export { sanityClient };', 'return { sanityClient };')
+
+  const factory = new Function('__deps', executableSource) as (deps: {
+    createClient: (config: ClientConfig) => Record<string, unknown>
+    importMeta: {env: {DEV: boolean; PROD: boolean}}
+  }) => {sanityClient: Record<string, unknown>}
+
+  return factory({
+    createClient,
+    importMeta: {env},
+  }).sanityClient
+}
+
+describe('vitePluginSanityClient request logging wrappers', () => {
+  it('does not wrap methods when logClientRequests is omitted', async () => {
+    const fetchImpl = vi.fn(async () => ({ok: true}))
+    const requestImpl = vi.fn(async () => ({status: 200}))
+    const createClient = vi.fn(() => ({fetch: fetchImpl, request: requestImpl}))
+
+    const sanityClient = buildVirtualClientModule({
+      logClientRequests: undefined,
+      env: {DEV: true, PROD: false},
+      createClient,
+    })
+
+    expect(sanityClient.fetch).toBe(fetchImpl)
+    expect(sanityClient.request).toBe(requestImpl)
+    expect(createClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps fetch in dev mode and preserves args + return value', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const fetchImpl = vi.fn(async () => ({title: 'Alien'}))
+    const createClient = vi.fn(() => ({fetch: fetchImpl}))
+
+    const sanityClient = buildVirtualClientModule({
+      logClientRequests: 'dev',
+      env: {DEV: true, PROD: false},
+      createClient,
+    })
+
+    const query = `*[_type == "movie"][0]`
+    const params = {slug: 'alien'}
+    const result = await (sanityClient.fetch as (q: string, p: Record<string, string>) => Promise<unknown>)(
+      query,
+      params,
+    )
+
+    expect(result).toEqual({title: 'Alien'})
+    expect(fetchImpl).toHaveBeenCalledWith(query, params)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    expect(String(infoSpy.mock.calls[0]?.[1])).toContain('query:')
+    expect(String(infoSpy.mock.calls[0]?.[1])).toContain('params:')
+    expect(String(infoSpy.mock.calls[0]?.[1])).toContain('"slug":"alien"')
+
+    infoSpy.mockRestore()
+  })
+
+  it('wraps request in build mode and preserves args + return value', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const requestImpl = vi.fn(async () => ({result: []}))
+    const createClient = vi.fn(() => ({request: requestImpl}))
+
+    const sanityClient = buildVirtualClientModule({
+      logClientRequests: 'build',
+      env: {DEV: false, PROD: true},
+      createClient,
+    })
+
+    const requestArgs = [{uri: '/data/query/production', method: 'GET'}]
+    const result = await (sanityClient.request as (arg: Record<string, string>) => Promise<unknown>)(
+      requestArgs[0],
+    )
+
+    expect(result).toEqual({result: []})
+    expect(requestImpl).toHaveBeenCalledWith(requestArgs[0])
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+
+    infoSpy.mockRestore()
+  })
+
+  it('rethrows underlying errors unchanged', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const failure = new Error('Network timeout')
+    const fetchImpl = vi.fn(async () => {
+      throw failure
+    })
+    const createClient = vi.fn(() => ({fetch: fetchImpl}))
+
+    const sanityClient = buildVirtualClientModule({
+      logClientRequests: 'always',
+      env: {DEV: false, PROD: true},
+      createClient,
+    })
+
+    await expect(
+      (sanityClient.fetch as (q: string) => Promise<unknown>)(`*[_type == "movie"]`),
+    ).rejects.toBe(failure)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+
+    infoSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.ts
@@ -41,6 +41,8 @@ export function vitePluginSanityClient(config: ClientConfig, options: PluginOpti
             const dimOpen = "\\u001B[2m";
             const dimClose = "\\u001B[22m";
             const viteLikeCyanOpen = "\\u001B[36m";
+            const greenOpen = "\\u001B[32m";
+            const yellowOpen = "\\u001B[33m";
             const colorClose = "\\u001B[0m";
             const pad2 = (value) => String(value).padStart(2, "0");
             const getTimestamp24h = () => {
@@ -52,6 +54,19 @@ export function vitePluginSanityClient(config: ClientConfig, options: PluginOpti
                 ":" +
                 pad2(now.getSeconds())
               );
+            };
+            const stringifyForLog = (value, maxLength = 300) => {
+              try {
+                const serialized = JSON.stringify(value);
+                if (typeof serialized !== "string") {
+                  return "[unserializable]";
+                }
+                return serialized.length > maxLength
+                  ? serialized.slice(0, maxLength) + "..."
+                  : serialized;
+              } catch {
+                return "[unserializable]";
+              }
             };
             const logRequestResult = (kind, label, startedAt, error) => {
               const durationMs = Math.round(performance.now() - startedAt);
@@ -71,7 +86,13 @@ export function vitePluginSanityClient(config: ClientConfig, options: PluginOpti
             if (fetchImpl) {
               sanityClient.fetch = async (...args) => {
                 const query = typeof args[0] === "string" ? args[0] : "[query]";
-                const label = query.slice(0, 120).replace(/\\s+/g, " ");
+                const queryValue = query.slice(0, 120).replace(/\\s+/g, " ");
+                const queryLabel = greenOpen + "query:" + colorClose + " " + queryValue;
+                const params =
+                  args.length > 1 && typeof args[1] !== "undefined"
+                    ? "  " + yellowOpen + "params:" + colorClose + " " + stringifyForLog(args[1])
+                    : "";
+                const label = queryLabel + params;
                 const startedAt = performance.now();
 
                 try {

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.ts
@@ -6,7 +6,13 @@ import type {PluginOption} from 'vite'
 const virtualModuleId = 'sanity:client'
 const resolvedVirtualModuleId = '\0' + virtualModuleId
 
-export function vitePluginSanityClient(config: ClientConfig) {
+type PluginOptions = {
+  logClientRequests?: 'dev' | 'build' | 'always'
+}
+
+export function vitePluginSanityClient(config: ClientConfig, options: PluginOptions = {}) {
+  const logClientRequests = options.logClientRequests
+
   return {
     name: 'sanity:client',
     resolveId(id: string) {
@@ -18,9 +24,89 @@ export function vitePluginSanityClient(config: ClientConfig) {
       if (id === resolvedVirtualModuleId) {
         return `
           import { createClient } from "@sanity/client";
-          export const sanityClient = createClient(
+          const sanityClient = createClient(
             ${serialize(config)}
           );
+
+          const logClientRequests = ${serialize(logClientRequests)};
+          const shouldLogInCurrentMode =
+            logClientRequests === "always" ||
+            (logClientRequests === "dev" && import.meta.env.DEV) ||
+            (logClientRequests === "build" && import.meta.env.PROD);
+          const shouldLogClientRequests =
+            shouldLogInCurrentMode &&
+            typeof window === "undefined";
+
+          if (shouldLogClientRequests) {
+            const dimOpen = "\\u001B[2m";
+            const dimClose = "\\u001B[22m";
+            const viteLikeCyanOpen = "\\u001B[36m";
+            const colorClose = "\\u001B[0m";
+            const pad2 = (value) => String(value).padStart(2, "0");
+            const getTimestamp24h = () => {
+              const now = new Date();
+              return (
+                pad2(now.getHours()) +
+                ":" +
+                pad2(now.getMinutes()) +
+                ":" +
+                pad2(now.getSeconds())
+              );
+            };
+            const logRequestResult = (kind, label, startedAt, error) => {
+              const durationMs = Math.round(performance.now() - startedAt);
+              const timestamp = dimOpen + getTimestamp24h() + dimClose;
+              const clientLabel = viteLikeCyanOpen + "[sanity:client]" + colorClose;
+              const message = clientLabel + " " + kind + " " + label + " (" + durationMs + "ms)";
+
+              if (error) {
+                console.error(timestamp, message, error);
+                return;
+              }
+
+              console.info(timestamp, message);
+            };
+
+            const fetchImpl = sanityClient.fetch?.bind(sanityClient);
+            if (fetchImpl) {
+              sanityClient.fetch = async (...args) => {
+                const query = typeof args[0] === "string" ? args[0] : "[query]";
+                const label = query.slice(0, 120).replace(/\\s+/g, " ");
+                const startedAt = performance.now();
+
+                try {
+                  const result = await fetchImpl(...args);
+                  logRequestResult("fetch", label, startedAt);
+                  return result;
+                } catch (error) {
+                  logRequestResult("fetch", label, startedAt, error);
+                  throw error;
+                }
+              };
+            }
+
+            const requestImpl = sanityClient.request?.bind(sanityClient);
+            if (requestImpl) {
+              sanityClient.request = async (...args) => {
+                const request = args[0] ?? {};
+                const method = request.method || "GET";
+                const uri = request.uri || request.url || "[request]";
+                const label = method + " " + uri;
+                const startedAt = performance.now();
+
+                try {
+                  const result = await requestImpl(...args);
+                  logRequestResult("request", label, startedAt);
+                  return result;
+                } catch (error) {
+                  logRequestResult("request", label, startedAt, error);
+                  throw error;
+                }
+              };
+            }
+          }
+
+          export { sanityClient };
         `
       }
     },

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.ts
@@ -43,6 +43,7 @@ export function vitePluginSanityClient(config: ClientConfig, options: PluginOpti
             const viteLikeCyanOpen = "\\u001B[36m";
             const greenOpen = "\\u001B[32m";
             const yellowOpen = "\\u001B[33m";
+            const magentaOpen = "\\u001B[35m";
             const colorClose = "\\u001B[0m";
             const pad2 = (value) => String(value).padStart(2, "0");
             const getTimestamp24h = () => {
@@ -81,6 +82,99 @@ export function vitePluginSanityClient(config: ClientConfig, options: PluginOpti
 
               console.info(timestamp, message);
             };
+            const parseSourceFromStackLine = (line) => {
+              const locationMatch = line.match(/(?:file:\\/\\/)?\\/[^\\s)]+:\\d+:\\d+/);
+              if (!locationMatch) {
+                return undefined;
+              }
+
+              const withLineAndColumn = locationMatch[0].replace(/^file:\\/\\//, "");
+              const absolutePath = withLineAndColumn.replace(/:\\d+:\\d+$/, "");
+              const normalizedPath = absolutePath.replace(/\\\\/g, "/");
+              const appPathIndex = normalizedPath.lastIndexOf("/apps/");
+              if (appPathIndex >= 0) {
+                return normalizedPath.slice(appPathIndex + 1);
+              }
+
+              const packagePathIndex = normalizedPath.lastIndexOf("/packages/");
+              if (packagePathIndex >= 0) {
+                return normalizedPath.slice(packagePathIndex + 1);
+              }
+
+              const srcPathIndex = normalizedPath.lastIndexOf("/src/");
+              if (srcPathIndex >= 0) {
+                return normalizedPath.slice(srcPathIndex + 1);
+              }
+
+              return normalizedPath;
+            };
+            const getSourceFromStack = () => {
+              try {
+                const stack = new Error().stack;
+                if (typeof stack !== "string") {
+                  return undefined;
+                }
+
+                const stackLines = stack.split("\\n").slice(1);
+                const candidates = [];
+                for (const line of stackLines) {
+                  const lowerLine = line.toLowerCase();
+                  if (
+                    lowerLine.includes("sanityclient.fetch") ||
+                    lowerLine.includes("logrequestresult") ||
+                    lowerLine.includes("getfetchsourceandargs") ||
+                    lowerLine.includes("getsourcefromstack") ||
+                    lowerLine.includes("vite-plugin-sanity-client")
+                  ) {
+                    continue;
+                  }
+
+                  const source = parseSourceFromStackLine(line);
+                  if (source) {
+                    const normalizedSource = source.toLowerCase();
+                    if (normalizedSource.endsWith(".astro")) {
+                      return source;
+                    }
+
+                    if (
+                      normalizedSource.includes("node_modules/") ||
+                      normalizedSource.includes("/load-query.") ||
+                      normalizedSource.includes("vite-plugin-sanity-client")
+                    ) {
+                      continue;
+                    }
+
+                    candidates.push(source);
+                  }
+                }
+
+                return candidates[0];
+              } catch {
+                // noop
+              }
+
+              return undefined;
+            };
+            const getFetchSourceAndArgs = (args) => {
+              const options = args[2];
+              const hasLoggerSource =
+                options &&
+                typeof options === "object" &&
+                !Array.isArray(options) &&
+                Object.prototype.hasOwnProperty.call(options, "loggerSource");
+              if (!hasLoggerSource) {
+                return {source: undefined, forwardArgs: args};
+              }
+
+              const {loggerSource, ...sanityFetchOptions} = options;
+              const source =
+                typeof loggerSource === "string" && loggerSource.trim().length > 0
+                  ? loggerSource.trim()
+                  : undefined;
+              const forwardArgs = [...args];
+              forwardArgs[2] = sanityFetchOptions;
+              return {source: source || getSourceFromStack(), forwardArgs};
+            };
 
             const fetchImpl = sanityClient.fetch?.bind(sanityClient);
             if (fetchImpl) {
@@ -92,11 +186,16 @@ export function vitePluginSanityClient(config: ClientConfig, options: PluginOpti
                   args.length > 1 && typeof args[1] !== "undefined"
                     ? "  " + yellowOpen + "params:" + colorClose + " " + stringifyForLog(args[1])
                     : "";
-                const label = queryLabel + params;
+                const {source: explicitSource, forwardArgs} = getFetchSourceAndArgs(args);
+                const source = explicitSource || getSourceFromStack();
+                const sourceLabel = source
+                  ? "  " + magentaOpen + "source:" + colorClose + " " + source
+                  : "";
+                const label = queryLabel + params + sourceLabel;
                 const startedAt = performance.now();
 
                 try {
-                  const result = await fetchImpl(...args);
+                  const result = await fetchImpl(...forwardArgs);
                   logRequestResult("fetch", label, startedAt);
                   return result;
                 } catch (error) {


### PR DESCRIPTION
This pull request introduces support for logging server-side requests made with the Sanity client in Astro projects. It adds a new `logClientRequests` option to the Sanity integration, allowing developers to control logging behavior for development, build, or always. The feature is documented and integrated into the configuration and plugin code, with examples provided for usage.

**New Feature: Server-side Sanity client request logging**
- Added a `logClientRequests` option (`'dev' | 'build' | 'always'`) to the Sanity integration config, enabling developers to choose when to log server-side Sanity client requests. [[1]](diffhunk://#diff-eefdcca2e8f43f60906f90f4e07c1ec244a0eba5e4b722f75fa5b93cc0d28527R11) [[2]](diffhunk://#diff-eefdcca2e8f43f60906f90f4e07c1ec244a0eba5e4b722f75fa5b93cc0d28527R24-R28)
- Updated the `vitePluginSanityClient` to accept and handle the new logging option, injecting logic into the virtual module to log requests and their durations, with colorized and timestamped output. [[1]](diffhunk://#diff-e1af30e5e9d70f66233f808b14ec5568beae694817d904b7dc0fb15f40253703L9-R15) [[2]](diffhunk://#diff-e1af30e5e9d70f66233f808b14ec5568beae694817d904b7dc0fb15f40253703L21-R109) [[3]](diffhunk://#diff-eefdcca2e8f43f60906f90f4e07c1ec244a0eba5e4b722f75fa5b93cc0d28527L51-R54)

**Configuration and Example Updates**
- Updated example Astro project configs (`apps/example/astro.config.mjs`, `apps/movies/astro.config.mjs`) to show usage of the new `logClientRequests` option. [[1]](diffhunk://#diff-ce7e127c7c6e8423bfe5fd0a7c909b8d74c3317564decb5a9043dda229c5f0b0R18) [[2]](diffhunk://#diff-ed4aba2cd3486cf446b20874fc378903c916284381144e458329fd44c19a4e3cR15-R16)
- Enhanced documentation in `packages/sanity-astro/README.md` to explain the `logClientRequests` option, its possible values, and usage examples. [[1]](diffhunk://#diff-1e329ca22089b7fffb766bee3ee8df8521e2c6c99a98885d8f59b7e9fa0b486fR61-R63) [[2]](diffhunk://#diff-1e329ca22089b7fffb766bee3ee8df8521e2c6c99a98885d8f59b7e9fa0b486fR93-R100)

Should solve #330 