### PR TITLE
Remove optimizeDep for dependency no longer in the package

### DIFF
--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -40,8 +40,7 @@ export default function sanityIntegration(
               include: [
                 'react-compiler-runtime',
                 'react-is',
-                'styled-components',
-                'lodash/startCase.js',
+                'styled-components'
               ],
             },
             plugins: [

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -40,7 +40,7 @@ export default function sanityIntegration(
               include: [
                 'react-compiler-runtime',
                 'react-is',
-                'styled-components'
+                'styled-components',
               ],
             },
             plugins: [


### PR DESCRIPTION
### Description

  Removes `lodash/startCase.js` from the `optimizeDeps.include` array. `@sanity/astro` doesn't import or use `lodash/startCase` — it's only a transitive dependency of the `sanity` Studio
  package. Projects that don't embed Studio don't have `lodash` installed, so Vite warns on every build:

  [WARN] [vite] Failed to resolve dependency: lodash/startCase.js, present in client 'optimizeDeps.include'

### What to review

  The one-line removal in `packages/sanity-astro/src/index.ts`.

### Testing

  Patched the built dist locally to remove the entry, ran `astro build` — warning is gone, build completes cleanly.