### PR TITLE
Update studio-route.astro

### DIFF
--- a/packages/sanity-astro/src/studio/studio-route.astro
+++ b/packages/sanity-astro/src/studio/studio-route.astro
@@ -1,9 +1,6 @@
 ---
 import {StudioComponent} from './studio-component'
-// Astro will warn about this being ignore, but it has to be there.
-export async function getStaticPaths() {
-  return [{params: {path: 'admin'}}]
-}
+
 // This route needs to run in "SPA" mode, so we need to set `prerender` to `false`
 export const prerender = false
 ---


### PR DESCRIPTION
This pull request makes a minor update to the `studio-route.astro` file by removing the unused `getStaticPaths` function, which is no longer necessary for this route. The route remains set to run in SPA mode with `prerender` disabled.