### PR TITLE
fix(example): guard Code.astro against missing code/language values

### DIFF
--- a/apps/example/src/components/Code.astro
+++ b/apps/example/src/components/Code.astro
@@ -2,6 +2,8 @@
 import {Prism} from '@astrojs/prism'
 
 const {node} = Astro.props
+const code = node?.code ?? ''
+const lang = node?.language ?? 'plaintext'
 ---
 
-<Prism lang={node.language} code={node.code} />
+{code && <Prism lang={lang} code={code} />}


### PR DESCRIPTION
## Problem

`pnpm build` failed during static prerendering of blog posts in the `example` app:

```
Cannot read properties of undefined (reading 'replace')
  at encode (.../prismjs/prism.js)
  at runHighlighterWithAstro (.../posts/_slug_.astro.mjs)
```

Some `code` blocks in the dataset have no `code` value. `Code.astro` passed `node.code` straight to `<Prism>`, so Prism received `undefined` and crashed the whole build.

## Fix

Default the missing values and skip rendering when there's no code:

```astro
const code = node?.code ?? ''
const lang = node?.language ?? 'plaintext'
---
{code && <Prism lang={lang} code={code} />}
```

## Verification

`pnpm build` now completes for all 4 packages (356 pages built in the example app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)