### PR TITLE
add invisible helper to much improve visual editing typing experience

### DIFF
--- a/packages/sanity-astro/src/visual-editing/visual-editing.astro
+++ b/packages/sanity-astro/src/visual-editing/visual-editing.astro
@@ -20,7 +20,6 @@ const {enabled, assureTypingInterval=1200, zIndex} = Astro.props
     // and if not defeated by negative value flag
     if (window.self === window.top) return
     if (assureTypingInterval <= 0) {
-      console.log ('PUBLIC_SANITY_ASSURE_TYPING_INTERVAL set negative, thus defeated.')
       return;
     }
 
@@ -34,9 +33,7 @@ const {enabled, assureTypingInterval=1200, zIndex} = Astro.props
       if (e.data?.type === 'presentation/preview-snapshots') {
         sessionStorage.setItem(FLAG, 'true');
         packetCount++;
-        // Verbose level: verifies packet flow without clutter
-        console.debug(`[Sanity Observer] Packet #${packetCount} buffered.`);
-      }
+     }
     });
 
     // 2. RECONCILE: Check for missed updates on page arrival
@@ -47,20 +44,12 @@ const {enabled, assureTypingInterval=1200, zIndex} = Astro.props
         // Clear flag immediately to ensure idempotency
         sessionStorage.removeItem(FLAG);
 
-        // Blue info: Formal acknowledgement of the blind window
-        console.info('%c[Sanity Sync] Blind window detected. Tail-end updates identified.', 'color: #0088ff; font-weight: bold;');
-
         // The 'Humanistic' pause for recursive queries to settle
         // n.b. we have to evaluate template-style, _and_ outside
         // the function call. These are Astro rules....
         setTimeout(() => {
-          // Yellow warning: The corrective sweep action
-          console.warn('%c[Sanity Sync] EXECUTING CORRECTIVE SWEEP.', 'color: #856404; font-weight: bold; background-color: #fff3cd; border: 1px solid #ffeeba; padding: 2px 4px;');
-          window.location.reload();
+         window.location.reload();
         }, assureTypingInterval); // must evaluate
-      } else {
-        // Green success: Confirmation of a high-fidelity 'atomic' load
-        console.log('%c[Sanity Sync] Page load stable. All characters accounted for.', 'color: #28a745;');
       }
     });
   })();

--- a/packages/sanity-astro/src/visual-editing/visual-editing.astro
+++ b/packages/sanity-astro/src/visual-editing/visual-editing.astro
@@ -2,10 +2,68 @@
 import {VisualEditingComponent, type VisualEditingOptions} from './visual-editing-component'
 
 export interface Props extends VisualEditingOptions {
-  enabled?: boolean
+  enabled?: boolean,
+  assureTypingInterval?: number,
 }
 
-const {enabled, zIndex} = Astro.props
+const {enabled, assureTypingInterval=1200, zIndex} = Astro.props
 ---
+<!--
+  NOTE: 'define:vars' implicitly enforces 'is:inline' behavior.
+  Do not combine them, as it can cause compilation syntax conflicts.
+  We must define the var to have it passed from js section
+-->
+<script define:vars={{ assureTypingInterval }}>
+  (function() {
+
+    // Only operate within the Studio's context,
+    // and if not defeated by negative value flag
+    if (window.self === window.top) return
+    if (assureTypingInterval <= 0) {
+      console.log ('PUBLIC_SANITY_ASSURE_TYPING_INTERVAL set negative, thus defeated.')
+      return;
+    }
+
+    const FLAG = 'sanity_sync_needed';
+    let packetCount = 0;
+
+    // 1. OBSERVE: Monitor the Studio's snapshot stream
+    window.addEventListener('message', (e) => {
+
+      // Catching the v5.6+ Snapshot volume
+      if (e.data?.type === 'presentation/preview-snapshots') {
+        sessionStorage.setItem(FLAG, 'true');
+        packetCount++;
+        // Verbose level: verifies packet flow without clutter
+        console.debug(`[Sanity Observer] Packet #${packetCount} buffered.`);
+      }
+    });
+
+    // 2. RECONCILE: Check for missed updates on page arrival
+    window.addEventListener('load', () => {
+      const needsSync = sessionStorage.getItem(FLAG) === 'true';
+
+      if (needsSync) {
+        // Clear flag immediately to ensure idempotency
+        sessionStorage.removeItem(FLAG);
+
+        // Blue info: Formal acknowledgement of the blind window
+        console.info('%c[Sanity Sync] Blind window detected. Tail-end updates identified.', 'color: #0088ff; font-weight: bold;');
+
+        // The 'Humanistic' pause for recursive queries to settle
+        // n.b. we have to evaluate template-style, _and_ outside
+        // the function call. These are Astro rules....
+        setTimeout(() => {
+          // Yellow warning: The corrective sweep action
+          console.warn('%c[Sanity Sync] EXECUTING CORRECTIVE SWEEP.', 'color: #856404; font-weight: bold; background-color: #fff3cd; border: 1px solid #ffeeba; padding: 2px 4px;');
+          window.location.reload();
+        }, assureTypingInterval); // must evaluate
+      } else {
+        // Green success: Confirmation of a high-fidelity 'atomic' load
+        console.log('%c[Sanity Sync] Page load stable. All characters accounted for.', 'color: #28a745;');
+      }
+    });
+  })();
+</script>
 
 {enabled ? <VisualEditingComponent client:only="react" zIndex={zIndex} /> : null}


### PR DESCRIPTION
### Description

Because of the actual non-closured protocol for content editing under Visual Editing for Astro, there's long been a problem for a content editor just trying to type in their text, needing to see how its formatting on the page as expected.

The problem is that they may well pause a moment just before completing a typing, as humans do, then add the final letters or just a period. 

The pause allows Astro Visual Editing to  launch the embedded browser refresh it uses to read fresh content. When the editor types during this pause, that typing will end up in the Content Lake, but not launch another refresh so that it's seen. 

Once the editor knows the problem, they may try to correct by typing a little more, intending to back it out, but as you can see this can only lead to similar lack of synchronizaiton, thus frustration.

This simple mod arranges an extra refresh to cover the blind interval. It is tunable via an environmental variable, but appears highly effective wihh the default in the code.

The result should be a much improved experience with Sanity Astro Visual Editing, without requiring a complex server cache protocol, which remains impractical with present and projected Astro 6 capabiliteis, not to say the load on Sanity engineering.

### What to revie
- the added code is all in the visual-editing.astro file in the package, under  src/visual-editing. 
- It add a script with event handling and use of browser storage to give best assurance of proper added refresh that mitigates the problem.

### Testing

1. simply verify that Visual Editing continues to operate with an SSR Astro server, as a boundary case
2. if you're familiar with the skipped typing problem, it should be gone, or very nearly gone
3. if you want to excite the problem, I do this by typing ff, pausing around a second, then typing h with the other hand. 
4. by varying the pause on a non-upgraded visual editing, you'll soon find the range where the h is skipped
5. appling similar delays on a matching server with the upgrade, you should just se the h quite reliably, and any other typing with pauses should be seen, inclluding the normal pickup if you actually typed across the invisible refresh. 

This is almost too simple to describe. The test works well even under dev mode; should be fine on a live server. If very severe refresh delays are present from the server, that's where the environmental can increase the refresh delay of the fix.

