### PR TITLE
fix(studio layout): overflow from hidden to auto

### DIFF
--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -98,7 +98,7 @@ export function StudioComponent(props: {history?: 'browser' | 'hash'}) {
         maxHeight: '100dvh',
         overscrollBehavior: 'none',
         WebkitFontSmoothing: 'antialiased',
-        overflow: 'hidden',
+        overflow: 'auto',
       }}
     >
       <Studio config={config} unstable_history={history} />


### PR DESCRIPTION
### Description

Embedded sanity-astro studio are not scrollable on small screens.

I edited the embedded studio layout overflow to `auto` for it to be scrollable on small screens. 
This is what work on other implementations like next-sanity as you can see [here with next-sanity](https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/src/studio/NextStudioLayout.tsx).

### What to review

Try to connect to a sanity studio emmbedded with sanity-astro on small screen like mobile and try to scroll on a document view.

### Testing

I didn't see side effects, BUT with this edit, the navbar is not fixed/sticky on small screens as it should be, and I don't know how to fix that.

I hope this helps. Thanks!