### PR TITLE
feat: forward all VisualEditingOptions on VisualEditingComponent

### DIFF
--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -331,7 +331,9 @@ const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLE
 </body>
 ```
 
-The `payload` tells you why the refresh fired: `payload.source` is `'manual'` when the editor clicks refresh in Presentation, or `'mutation'` when a document changes. The same subpath also accepts `history` if you need to take over URL syncing, and `onSuspiciousStega` for opt-in reporting when stega appears in unsafe placements (`class`, `href`, `<head>`, scripts, and similar).
+The `payload` tells you why the refresh fired: `payload.source` is `'manual'` when the editor clicks refresh in Presentation, or `'mutation'` when a document changes.
+
+`VisualEditingComponent` accepts every option that `<VisualEditing />` from `@sanity/visual-editing/react` does, and forwards them all. Beyond `refresh`, the ones worth knowing about are `history` if you need to take over URL syncing, `onSuspiciousStega` for opt-in reporting when stega appears in unsafe placements (`class`, `href`, `<head>`, scripts, and similar), `onPerspectiveChange` to keep server-side fetching on the same perspective as the Studio driving the preview, and the alpha `components` / `plugins` resolvers for custom overlay UI such as an insert menu on an array field. `refresh` and `history` fall back to the defaults above when you don't pass them; everything else is passed straight through.
 
 ### 2. Add the Presentation tool to the Studio
 

--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -8,10 +8,7 @@ import {applyPresentationHistoryUpdate, getPresentationUrl, shouldPublishUrl} fr
 
 export type {SuspiciousStegaReport}
 
-export type VisualEditingOptions = Pick<
-  InternalVisualEditingOptions,
-  'zIndex' | 'refresh' | 'history' | 'keepStegaOnCopy' | 'onSuspiciousStega'
->
+export type VisualEditingOptions = InternalVisualEditingOptions
 type HistoryAdapter = NonNullable<InternalVisualEditingOptions['history']>
 type HistoryNavigate = Parameters<HistoryAdapter['subscribe']>[0]
 
@@ -157,12 +154,10 @@ export function VisualEditingComponent(props: VisualEditingOptions) {
 
   return (
     <InternalVisualEditing
+      {...props}
       portal
       history={props.history ?? defaultHistory}
-      zIndex={props.zIndex}
       refresh={props.refresh ?? defaultRefresh}
-      keepStegaOnCopy={props.keepStegaOnCopy}
-      onSuspiciousStega={props.onSuspiciousStega}
     />
   )
 }


### PR DESCRIPTION
### Description

Follow-up to #401 and #417, which each widened the `Pick` to let one more option through. The list still leaves out the alpha `components` and `plugins` resolvers and `onPerspectiveChange`.

This forwards everything instead. `VisualEditingOptions` becomes an alias of the option type from `@sanity/visual-editing/react`, and props are spread onto the inner component. `portal`, `history` and `refresh` are applied after the spread so the current defaults still win, and behaviour is unchanged for existing usage.

What prompted it: rendering an insert menu on an array field needs `components`, and the only way to reach that today is forking the component, which is what #401 set out to make unnecessary.

### What to review

`visual-editing-component.tsx` is the whole change, five lines added and eight removed. Spread ordering is the part that matters: props first, then `portal`, `history` and `refresh` so those stay authoritative.

Curating the list makes sense on the `.astro` wrapper, which genuinely can't serialize a function through `client:only`. The React component has no equivalent constraint. The wrapper is untouched and its `Pick` resolves the same way against the wider type.

One call for you: this puts the alpha `components` and `plugins` on an otherwise stable type. Happy to go back to an explicit list with just those added if you'd rather keep them out.

### Testing

`pnpm test` (26 tests), `pnpm build`, `tsc --noEmit` and prettier all clean.

I checked the type change with a throwaway component passing `components`, which fails on the current `Pick` with TS2322 and compiles after.

No new automated test, same reasoning as #401: it needs a DOM render of the React component and the package has no jsdom or testing-library configured. Can add that setup if you want it.

Related: #421.
