### PR TITLE
fix: report the preview URL to Presentation on history subscribe

### DIFF
--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -134,6 +134,9 @@ export function VisualEditingComponent(props: VisualEditingOptions) {
         const currentUrl = getPresentationUrl(window.location)
         lastUrlRef.current = currentUrl
         lastPublishedAtRef.current = Date.now()
+        // Report the URL on every subscribe, since Presentation can't navigate the frame
+        // until it has one and an MPA has no router event to report it from.
+        _navigate({type: 'push', title: document.title, url: currentUrl})
         return () => {
           // Keep navigation publishing alive briefly for immediate link clicks
           // after edit mode is toggled off, then release it to respect off mode.


### PR DESCRIPTION
### Description

Typing a path into Presentation's address bar does nothing until you've clicked a link inside the preview.

`PresentationTool` gates the effect that drives the frame on `frameStateRef.current.url` being set, so it can't navigate until the frame has reported a URL. With the default history adapter on an MPA nothing reports one: a routed app publishes from a load-time history event, and `syncCurrentUrl()` can't cover it because `lastUrlRef` already matches by the time `navigateRef` is assigned. Link clicks worked because those force-publish.

This reports the URL from `defaultHistory.subscribe`, so it also fires on comlink reconnect.

### What to review

One line plus a comment in `defaultHistory.subscribe`. It reports `currentUrl`, the value already recorded on the two lines above. Only `defaultHistory` is touched, so anyone passing their own adapter is unaffected.

Re-reporting an unchanged URL looks harmless: the `visual-editing/navigate` handler only calls `handleNavigate` when the incoming URL differs from the one it holds. The case I'm less sure of is that after a Studio-driven nav the effect stores `params.preview`, which may be relative, while a later frame report stores the resolved absolute form, so the two can differ and cost one redundant `handleNavigate`. It converges rather than loops, but you'd know better than me whether that's worth caring about.

### Testing

`pnpm test` (26 tests), `pnpm build`, `tsc --noEmit` and prettier all clean.

The change has been running as a patch over this component in an embedded Astro Studio since early June, where it fixed the symptom above. Address bar navigation works from first load with it, and needs a preview link click first without it.

No new automated test, same reasoning as #401: it needs a DOM render of the React component and the package has no jsdom or testing-library configured. Can add that setup if you want it.

Related: #420.
