### PR TITLE
chore: replace Prettier with Oxfmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,5 @@
 ---
-name: Prettier
+name: Format
 
 on:
   push:
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   run:
-    name: Can the code be prettier? 🤔
+    name: Can the code be formatted? 🤔
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,10 +22,6 @@ jobs:
           cache: pnpm
           node-version: lts/*
       - run: pnpm install --dev --ignore-scripts
-      - uses: actions/cache@v4
-        with:
-          path: node_modules/.cache/prettier/.prettier-cache
-          key: prettier-${{ hashFiles('pnpm-lock.yaml') }}
       - run: pnpm format
       - run: git restore .github/workflows
       - uses: actions/create-github-app-token@v2
@@ -36,9 +32,9 @@ jobs:
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           body: I ran `pnpm format` 🧑‍💻
-          branch: actions/prettier
-          commit-message: "chore(prettier): 🤖 ✨"
+          branch: actions/format
+          commit-message: 'chore(format): 🤖 ✨'
           labels: 🤖 bot
           sign-commits: true
-          title: "chore(prettier): 🤖 ✨"
+          title: 'chore(format): 🤖 ✨'
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [closed]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "quoteProps": "consistent",
+  "sortImports": true,
+  "sortPackageJson": {"sortScripts": true},
+  "ignorePatterns": ["dist/**", ".next/**", "pnpm-lock.yaml", "CHANGELOG.md"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,0 @@
-dist
-CHANGELOG.md
-pnpm-lock.yaml

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,9 +1,0 @@
-const preset = require('@sanity/prettier-config')
-
-/** @type {import("prettier").Config} */
-const config = {
-  ...preset,
-  plugins: [...preset.plugins, 'prettier-plugin-astro'],
-}
-
-module.exports = config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,12 @@ This repo is the official **Sanity + Astro** integration ([`@sanity/astro`](./pa
 
 ### Services
 
-| App (`--filter`) | Dev command | Port | Notes |
-|------------------|-------------|------|-------|
-| `example` | `pnpm dev:example` | 4322 | Static blog demo. Reads **published** content from Sanity Cloud, **no token required**. Best token-free smoke test. |
-| `example-ssr` | `pnpm dev:example-ssr` | 4323 | SSR variant (Vercel adapter). |
-| `example-latest` | `pnpm dev:example-latest` | 4324 | Same demo on newer Astro/Sanity. |
-| `movies` | `pnpm dev:movies` | 4321 | Movies + Visual Editing demo. |
+| App (`--filter`) | Dev command               | Port | Notes                                                                                                               |
+| ---------------- | ------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------- |
+| `example`        | `pnpm dev:example`        | 4322 | Static blog demo. Reads **published** content from Sanity Cloud, **no token required**. Best token-free smoke test. |
+| `example-ssr`    | `pnpm dev:example-ssr`    | 4323 | SSR variant (Vercel adapter).                                                                                       |
+| `example-latest` | `pnpm dev:example-latest` | 4324 | Same demo on newer Astro/Sanity.                                                                                    |
+| `movies`         | `pnpm dev:movies`         | 4321 | Movies + Visual Editing demo.                                                                                       |
 
 Each app also mounts an **embedded Sanity Studio at `/admin`** (e.g. `http://localhost:4322/admin`).
 
@@ -20,8 +20,8 @@ Each app also mounts an **embedded Sanity Studio at `/admin`** (e.g. `http://loc
 - **Build the library before/with dev.** Apps depend on `@sanity/astro` via `workspace:^` and consume its `dist/`. The root `dev:*` scripts already run `pnpm --filter @sanity/astro build` first, so always start apps via those root scripts (not `astro dev` directly). If you change library source in `packages/sanity-astro`, rebuild it (`pnpm --filter @sanity/astro build`, or `pnpm --filter @sanity/astro dev` for watch mode) for apps to pick up changes.
 - **`movies` requires a secret.** Its dev script sets `PUBLIC_SANITY_VISUAL_EDITING_ENABLED=true`, which forces Draft Mode and throws `The SANITY_API_READ_TOKEN environment variable is required in Draft Mode` (HTTP 500) unless a token is provided. For a token-free demo use `example` instead. The token must be a **viewer** (or higher) token for the project the app targets — the committed config points at Sanity's public `movies` demo project (`4j2qnyob`), so the token must belong to a Sanity account with access to that project. See **Providing the `movies` token** below for how to wire it in. To demo against a project you own instead, temporarily change `projectId`/`dataset` in `apps/movies/astro.config.mjs` and seed a `movie` document (fields `title` + `slug`; the homepage queries `*[_type == 'movie']`).
 - **Tokens are project-scoped.** A Sanity API token only works against its own project host; used against a different project's host the Query API returns HTTP 401 `Session does not match project host`. So a token for one projectId cannot authenticate requests for another.
-- **The token must live in a `.env` file, not just the process env.** `load-query.ts` reads `import.meta.env.SANITY_API_READ_TOKEN`, and Astro/Vite only expose *non-`PUBLIC_`* vars to `import.meta.env` when they come from a `.env` file. A token exported into the shell / injected as a process env var is NOT picked up — put it in `apps/movies/.env`.
-- **`pnpm lint` executes 0 tasks.** No workspace package defines a `lint` script, so `turbo run lint` reports "No tasks were executed" (this matches CI and is expected — not a failure). Running `eslint` directly currently fails because the shared `eslint-config-custom` pulls in `eslint-config-next`, whose parser needs `next` (not installed). The effective style gate is Prettier: `pnpm format` (write) or `npx prettier --check .`. Note some files in the repo are already not Prettier-clean on `main`.
+- **The token must live in a `.env` file, not just the process env.** `load-query.ts` reads `import.meta.env.SANITY_API_READ_TOKEN`, and Astro/Vite only expose _non-`PUBLIC_`_ vars to `import.meta.env` when they come from a `.env` file. A token exported into the shell / injected as a process env var is NOT picked up — put it in `apps/movies/.env`.
+- **`pnpm lint` executes 0 tasks.** No workspace package defines a `lint` script, so `turbo run lint` reports "No tasks were executed" (this matches CI and is expected — not a failure). Running `eslint` directly currently fails because the shared `eslint-config-custom` pulls in `eslint-config-next`, whose parser needs `next` (not installed). The effective style gate is Oxfmt: `pnpm format` (write) or `pnpm oxfmt --check`.
 - **Unit tests:** `pnpm --filter @sanity/astro test` (vitest). **Integration tests** (`pnpm --filter @sanity/astro test:integration`) use Playwright and require Chromium: `pnpm --filter @sanity/astro exec playwright install chromium --with-deps`, and a freshly built `dist/`.
 - **Node/pnpm:** `@sanity/astro` requires Node `>=20.19.0 || >=22.12.0`; `packageManager` is pinned to `pnpm@9.15.9`.
 - For embedded Studio login to work against a Sanity project, the dev origin (e.g. `http://localhost:4322`) must be allow-listed in that project's CORS settings.

--- a/apps/example-latest/astro.config.mjs
+++ b/apps/example-latest/astro.config.mjs
@@ -1,6 +1,6 @@
+import react from '@astrojs/react'
 import sanity from '@sanity/astro'
 import {defineConfig} from 'astro/config'
-import react from '@astrojs/react'
 
 // https://astro.build/config
 export default defineConfig({

--- a/apps/example-latest/sanity.config.ts
+++ b/apps/example-latest/sanity.config.ts
@@ -2,6 +2,7 @@ import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {sanityClient} from 'sanity:client'
+
 import {schemaTypes} from './schemas'
 
 const {projectId, dataset} = sanityClient.config()

--- a/apps/example-ssr/astro.config.mjs
+++ b/apps/example-ssr/astro.config.mjs
@@ -1,7 +1,7 @@
+import react from '@astrojs/react'
+import vercel from '@astrojs/vercel'
 import sanity from '@sanity/astro'
 import {defineConfig} from 'astro/config'
-import vercel from '@astrojs/vercel'
-import react from '@astrojs/react'
 
 // https://astro.build/config
 export default defineConfig({

--- a/apps/example-ssr/sanity.config.ts
+++ b/apps/example-ssr/sanity.config.ts
@@ -1,6 +1,7 @@
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
+
 import {schemaTypes} from './schemas'
 
 export const projectId = import.meta.env.PUBLIC_SANITY_PROJECT_ID! || '3do82whm'

--- a/apps/example/astro.config.mjs
+++ b/apps/example/astro.config.mjs
@@ -1,6 +1,6 @@
+import react from '@astrojs/react'
 import sanity from '@sanity/astro'
 import {defineConfig} from 'astro/config'
-import react from '@astrojs/react'
 
 // https://astro.build/config
 export default defineConfig({

--- a/apps/example/sanity.config.ts
+++ b/apps/example/sanity.config.ts
@@ -2,6 +2,7 @@ import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {sanityClient} from 'sanity:client'
+
 import {schemaTypes} from './schemas'
 
 const {projectId, dataset} = sanityClient.config()

--- a/apps/movies/astro.config.mjs
+++ b/apps/movies/astro.config.mjs
@@ -1,8 +1,7 @@
-import {defineConfig} from 'astro/config'
-
 import react from '@astrojs/react'
 import vercel from '@astrojs/vercel'
 import sanity from '@sanity/astro'
+import {defineConfig} from 'astro/config'
 
 // https://astro.build/config
 export default defineConfig({

--- a/apps/movies/sanity.config.ts
+++ b/apps/movies/sanity.config.ts
@@ -1,7 +1,8 @@
 import {defineConfig} from 'sanity'
-import {structureTool} from 'sanity/structure'
-import {schemaTypes} from './schemaTypes'
 import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
+import {structureTool} from 'sanity/structure'
+
+import {schemaTypes} from './schemaTypes'
 
 const branchUrl =
   (import.meta.env?.['VERCEL_BRANCH_URL'] as string | undefined) ??

--- a/apps/movies/schemaTypes/index.ts
+++ b/apps/movies/schemaTypes/index.ts
@@ -1,11 +1,11 @@
 import blockContent from './blockContent'
-import crewMember from './crewMember'
 import castMember from './castMember'
+import crewMember from './crewMember'
 import movie from './movie'
 import person from './person'
-import screening from './screening'
-import plotSummary from './plotSummary'
 import plotSummaries from './plotSummaries'
+import plotSummary from './plotSummary'
+import screening from './screening'
 
 export const schemaTypes = [
   // Document types

--- a/apps/movies/schemaTypes/movie.ts
+++ b/apps/movies/schemaTypes/movie.ts
@@ -1,5 +1,5 @@
-import {defineField, defineType} from 'sanity'
 import {MdLocalMovies as icon} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
 export default defineType({
   name: 'movie',

--- a/apps/movies/schemaTypes/person.ts
+++ b/apps/movies/schemaTypes/person.ts
@@ -1,5 +1,5 @@
-import {defineField, defineType} from 'sanity'
 import {MdPerson as icon} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
 export default defineType({
   name: 'person',

--- a/apps/movies/schemaTypes/screening.ts
+++ b/apps/movies/schemaTypes/screening.ts
@@ -1,5 +1,5 @@
-import {defineField, defineType} from 'sanity'
 import {MdLocalPlay as icon} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
 export default defineType({
   name: 'screening',

--- a/package.json
+++ b/package.json
@@ -13,16 +13,14 @@
     "dev:example-latest": "pnpm --filter @sanity/astro build && turbo run dev --filter=example-latest",
     "dev:example-ssr": "pnpm --filter @sanity/astro build && turbo run dev --filter=example-ssr",
     "dev:movies": "pnpm --filter @sanity/astro build && turbo run dev --filter=movies",
-    "format": "prettier --write .",
+    "format": "oxfmt",
     "lint": "turbo run lint"
   },
   "devDependencies": {
-    "@sanity/prettier-config": "^1.0.3",
     "@turbo/gen": "^1.13.4",
     "eslint": "^8.57.1",
     "eslint-config-custom": "*",
-    "prettier": "^3.5.3",
-    "prettier-plugin-astro": "^0.14.1",
+    "oxfmt": "^0.61.0",
     "rimraf": "^5.0.7",
     "turbo": "^1.13.4"
   },

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -121,9 +121,7 @@ export default defineConfig({
   dataset: '<YOUR-DATASET-NAME>',
   plugins: [structureTool()],
   schema: {
-    types: [
-      /* your content types here*/
-    ],
+    types: [/* your content types here*/],
   },
 })
 ```

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -4,20 +4,27 @@
   "description": "Official Sanity Astro integration",
   "keywords": [
     "astro-integration",
-    "withastro",
-    "sanity"
+    "sanity",
+    "withastro"
   ],
   "homepage": "https://www.sanity.io/plugins/sanity-astro",
   "bugs": {
     "url": "https://github.com/sanity-io/sanity-astro/issues"
   },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity-astro.git",
     "directory": "packages/sanity-astro"
   },
-  "license": "MIT",
-  "author": "Sanity.io <hello@sanity.io>",
+  "files": [
+    "dist",
+    "src/studio",
+    "src/visual-editing",
+    "module.d.ts"
+  ],
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -40,13 +47,9 @@
       "default": "./src/visual-editing/visual-editing-component.tsx"
     }
   },
-  "types": "./dist/types/index.d.ts",
-  "files": [
-    "dist",
-    "src/studio",
-    "src/visual-editing",
-    "module.d.ts"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rimraf dist && vite build && pnpm copyStudio && pnpm copy:visual-editing",
     "clean": "rimraf dist && rimraf .turbo && rimraf node_modules",
@@ -86,8 +89,5 @@
   },
   "engines": {
     "node": ">=20.19.0 || >=22.12.0"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/sanity-astro/src/index.test.ts
+++ b/packages/sanity-astro/src/index.test.ts
@@ -1,7 +1,11 @@
 import {describe, expect, it, vi} from 'vitest'
+
 import sanityIntegration from './index'
+import {
+  SANITY_MODULE_DEDUPE,
+  vitePluginSanityModuleDedupe,
+} from './vite-plugin-sanity-module-dedupe'
 import {vitePluginSanityStudioChunkWarning} from './vite-plugin-sanity-studio-chunk-warning'
-import {SANITY_MODULE_DEDUPE, vitePluginSanityModuleDedupe} from './vite-plugin-sanity-module-dedupe'
 
 async function runSetup({
   output = 'static',

--- a/packages/sanity-astro/src/index.ts
+++ b/packages/sanity-astro/src/index.ts
@@ -1,11 +1,12 @@
-import type {AstroIntegration} from 'astro'
-import {vitePluginSanityClient} from './vite-plugin-sanity-client'
-import {vitePluginSanityStudio} from './vite-plugin-sanity-studio'
-import {vitePluginSanityStudioHashRouter} from './vite-plugin-sanity-studio-hash-router'
-import {vitePluginSanityStudioChunkWarning} from './vite-plugin-sanity-studio-chunk-warning'
-import {vitePluginSanityModuleDedupe} from './vite-plugin-sanity-module-dedupe'
 import type {ClientConfig} from '@sanity/client'
+import type {AstroIntegration} from 'astro'
+
 import {normalizeStudioBasePath, studioRoutePattern} from './studio-base-path'
+import {vitePluginSanityClient} from './vite-plugin-sanity-client'
+import {vitePluginSanityModuleDedupe} from './vite-plugin-sanity-module-dedupe'
+import {vitePluginSanityStudio} from './vite-plugin-sanity-studio'
+import {vitePluginSanityStudioChunkWarning} from './vite-plugin-sanity-studio-chunk-warning'
+import {vitePluginSanityStudioHashRouter} from './vite-plugin-sanity-studio-hash-router'
 
 type IntegrationOptions = ClientConfig & {
   studioBasePath?: string

--- a/packages/sanity-astro/src/integration/astro-dev-react-dedupe.test.ts
+++ b/packages/sanity-astro/src/integration/astro-dev-react-dedupe.test.ts
@@ -1,8 +1,10 @@
 import {existsSync} from 'node:fs'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
+
 import {chromium, type ConsoleMessage, type Page} from 'playwright'
 import {beforeAll, describe, expect, it} from 'vitest'
+
 import {startAstroDevServer} from './dev-server'
 import {collectDuplicateModuleErrors} from './duplicate-module-errors'
 

--- a/packages/sanity-astro/src/studio-base-path.test.ts
+++ b/packages/sanity-astro/src/studio-base-path.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest'
+
 import {normalizeStudioBasePath, studioRoutePattern} from './studio-base-path'
 
 describe('studio base path helpers', () => {

--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
 import {createHashHistory, type History, type Listener} from 'history'
+import React from 'react'
+import {Studio} from 'sanity'
 // @ts-ignore
 import {config} from 'sanity:studio'
-import {Studio} from 'sanity'
 
 if (!config) {
   throw new Error(

--- a/packages/sanity-astro/src/visual-editing/history.test.ts
+++ b/packages/sanity-astro/src/visual-editing/history.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, vi} from 'vitest'
+
 import {applyPresentationHistoryUpdate, getPresentationUrl, shouldPublishUrl} from './history'
 
 describe('visual editing history helpers', () => {

--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
 import {
   VisualEditing as InternalVisualEditing,
   type SuspiciousStegaReport,
   type VisualEditingOptions as InternalVisualEditingOptions,
 } from '@sanity/visual-editing/react'
+import React from 'react'
+
 import {applyPresentationHistoryUpdate, getPresentationUrl, shouldPublishUrl} from './history'
 
 export type {SuspiciousStegaReport}

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.test.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.test.ts
@@ -1,6 +1,7 @@
-import {describe, expect, it, vi} from 'vitest'
-import {vitePluginSanityClient} from './vite-plugin-sanity-client'
 import type {ClientConfig} from '@sanity/client'
+import {describe, expect, it, vi} from 'vitest'
+
+import {vitePluginSanityClient} from './vite-plugin-sanity-client'
 
 type LogMode = 'dev' | 'build' | 'always' | undefined
 
@@ -96,11 +97,13 @@ describe('vitePluginSanityClient request logging wrappers', () => {
     try {
       const query = `*[_type == "movie"][0]`
       const params = {slug: 'alien'}
-      const result = await (sanityClient.fetch as (
-        q: string,
-        p: Record<string, string>,
-        options: {filterResponse: boolean},
-      ) => Promise<unknown>)(query, params, {filterResponse: false})
+      const result = await (
+        sanityClient.fetch as (
+          q: string,
+          p: Record<string, string>,
+          options: {filterResponse: boolean},
+        ) => Promise<unknown>
+      )(query, params, {filterResponse: false})
 
       expect(result).toEqual({title: 'Alien'})
       expect(fetchImpl).toHaveBeenCalledWith(query, params, {filterResponse: false})
@@ -129,9 +132,9 @@ describe('vitePluginSanityClient request logging wrappers', () => {
     })
 
     const requestArgs = [{uri: '/data/query/production', method: 'GET'}]
-    const result = await (sanityClient.request as (arg: Record<string, string>) => Promise<unknown>)(
-      requestArgs[0],
-    )
+    const result = await (
+      sanityClient.request as (arg: Record<string, string>) => Promise<unknown>
+    )(requestArgs[0])
 
     expect(result).toEqual({result: []})
     expect(requestImpl).toHaveBeenCalledWith(requestArgs[0])

--- a/packages/sanity-astro/src/vite-plugin-sanity-client.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-client.ts
@@ -1,6 +1,6 @@
 import type {ClientConfig} from '@sanity/client'
-import type {PartialDeep} from 'type-fest'
 import serialize from 'serialize-javascript'
+import type {PartialDeep} from 'type-fest'
 import type {PluginOption} from 'vite'
 
 const virtualModuleId = 'sanity:client'

--- a/packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.test.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.test.ts
@@ -1,5 +1,7 @@
 import path from 'node:path'
+
 import {describe, expect, it} from 'vitest'
+
 import {
   buildSanityModuleAliases,
   resolveSanityModuleDedupe,
@@ -15,10 +17,12 @@ type PluginLike = {
   config?: (
     config: {root?: string},
     env: {command: string; mode: string},
-  ) => {
-    optimizeDeps?: {include?: string[]}
-    resolve?: {dedupe?: string[]; alias?: unknown[]}
-  } | undefined
+  ) =>
+    | {
+        optimizeDeps?: {include?: string[]}
+        resolve?: {dedupe?: string[]; alias?: unknown[]}
+      }
+    | undefined
 }
 
 describe('vitePluginSanityModuleDedupe', () => {
@@ -57,9 +61,9 @@ describe('vitePluginSanityModuleDedupe', () => {
 
     expect(config?.optimizeDeps?.include).toEqual(resolved)
     expect(resolved.length).toBeGreaterThan(0)
-    expect(resolved.every((dependency) => SANITY_OPTIMIZE_DEPS_CANDIDATES.includes(dependency as never))).toBe(
-      true,
-    )
+    expect(
+      resolved.every((dependency) => SANITY_OPTIMIZE_DEPS_CANDIDATES.includes(dependency as never)),
+    ).toBe(true)
   })
 
   it('aliases consuming-project module roots for sanity and styled-components', () => {

--- a/packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.ts
@@ -1,5 +1,6 @@
 import {createRequire} from 'node:module'
 import path from 'node:path'
+
 import type {PluginOption, UserConfig} from 'vite'
 
 /**
@@ -58,9 +59,7 @@ export function resolveSanityOptimizeDeps(projectRoot: string): string[] {
 }
 
 export function resolveSanityModuleDedupe(projectRoot: string): string[] {
-  return SANITY_MODULE_DEDUPE.filter((dependency) =>
-    canResolveDependency(projectRoot, dependency),
-  )
+  return SANITY_MODULE_DEDUPE.filter((dependency) => canResolveDependency(projectRoot, dependency))
 }
 
 export function buildSanityModuleAliases(projectRoot: string) {

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.test.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest'
+
 import {
   collectStudioChunkFiles,
   getOversizedNonStudioChunks,

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio-chunk-warning.ts
@@ -64,7 +64,10 @@ export function collectStudioChunkFiles(chunksByFileName: Map<string, ChunkLike>
   return studioChunkFiles
 }
 
-export function formatLargeChunkWarning(limitInKb: number, oversizedChunkFileNames: string[]): string {
+export function formatLargeChunkWarning(
+  limitInKb: number,
+  oversizedChunkFileNames: string[],
+): string {
   const chunkList = oversizedChunkFileNames.map((fileName) => `- ${fileName}`).join('\n')
   return `Some chunks are larger than ${limitInKb} kB after minification. Consider:
 ${chunkList}

--- a/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-studio.ts
@@ -1,5 +1,6 @@
 import type {PartialDeep} from 'type-fest'
 import type {PluginOption} from 'vite'
+
 import {normalizeStudioBasePath} from './studio-base-path'
 
 export function vitePluginSanityStudio(resolvedOptions: {

--- a/packages/sanity-astro/vite.config.ts
+++ b/packages/sanity-astro/vite.config.ts
@@ -1,5 +1,6 @@
-import {defineConfig, type Plugin} from 'vite'
 import path from 'path'
+
+import {defineConfig, type Plugin} from 'vite'
 import dts from 'vite-plugin-dts'
 
 const name = 'sanity-astro'

--- a/packages/sanity-astro/vitest.config.ts
+++ b/packages/sanity-astro/vitest.config.ts
@@ -4,10 +4,6 @@ export default defineConfig({
   test: {
     hookTimeout: 240_000,
     testTimeout: 240_000,
-    exclude: [
-      'dist/**',
-      'node_modules/**',
-      'src/integration/**',
-    ],
+    exclude: ['dist/**', 'node_modules/**', 'src/integration/**'],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ importers:
 
   .:
     devDependencies:
-      '@sanity/prettier-config':
-        specifier: ^1.0.3
-        version: 1.0.3(prettier@3.9.1)
       '@turbo/gen':
         specifier: ^1.13.4
         version: 1.13.4(@types/node@22.13.4)(typescript@5.9.3)
@@ -24,12 +21,9 @@ importers:
       eslint-config-custom:
         specifier: '*'
         version: 0.0.0(eslint@8.57.1)(typescript@5.9.3)
-      prettier:
-        specifier: ^3.5.3
-        version: 3.9.1
-      prettier-plugin-astro:
-        specifier: ^0.14.1
-        version: 0.14.1
+      oxfmt:
+        specifier: ^0.61.0
+        version: 0.61.0
       rimraf:
         specifier: ^5.0.7
         version: 5.0.10
@@ -62,7 +56,7 @@ importers:
         version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@sanity/vision':
         specifier: ^5.31.1
-        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       astro:
         specifier: 5.4.1
         version: 5.4.1(@types/node@22.13.4)(@vercel/functions@2.2.13)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.39.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -80,7 +74,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sanity:
         specifier: ^5.31.1
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.3
         version: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -107,7 +101,7 @@ importers:
         version: 2.1.1
       '@sanity/vision':
         specifier: ^6.2.0
-        version: 6.2.0(ewqdenbiawvpe6jazzn42q2tzy)
+        version: 6.2.0(4wo6afo3dnmdlw2vy6mr2wab44)
       astro:
         specifier: ^7.0.3
         version: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.13.4)(@vercel/functions@2.2.13)(jiti@2.7.0)(rollup@4.52.5)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -131,7 +125,7 @@ importers:
         version: 19.2.7
       sanity:
         specifier: ^6.2.0
-        version: 6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(immer@10.2.0)(jiti@2.7.0)(node-fetch@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+        version: 6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(immer@10.2.0)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.3
         version: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -164,7 +158,7 @@ importers:
         version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@sanity/vision':
         specifier: ^5.31.1
-        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       astro:
         specifier: 5.4.1
         version: 5.4.1(@types/node@22.13.4)(@vercel/functions@2.2.13)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.39.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -179,7 +173,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sanity:
         specifier: ^5.31.1
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.3
         version: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -224,7 +218,7 @@ importers:
         version: 5.5.0(react@19.2.7)
       sanity:
         specifier: ^5.31.1
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.3
         version: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -267,7 +261,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sanity:
         specifier: ^5.31.1
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       serialize-javascript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -2467,13 +2461,123 @@ packages:
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
+  '@oxfmt/binding-android-arm-eabi@0.61.0':
+    resolution: {integrity: sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.61.0':
+    resolution: {integrity: sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.61.0':
+    resolution: {integrity: sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.61.0':
+    resolution: {integrity: sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.61.0':
+    resolution: {integrity: sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.61.0':
+    resolution: {integrity: sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.61.0':
+    resolution: {integrity: sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.61.0':
+    resolution: {integrity: sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.61.0':
+    resolution: {integrity: sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
+    resolution: {integrity: sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
+    resolution: {integrity: sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.61.0':
+    resolution: {integrity: sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.61.0':
+    resolution: {integrity: sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.61.0':
+    resolution: {integrity: sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.61.0':
+    resolution: {integrity: sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.61.0':
+    resolution: {integrity: sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.61.0':
+    resolution: {integrity: sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.61.0':
+    resolution: {integrity: sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.61.0':
+    resolution: {integrity: sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@pkgr/core@0.1.1':
-    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3148,11 +3252,6 @@ packages:
   '@sanity/presentation-comlink@2.2.0':
     resolution: {integrity: sha512-uHiiJNWER36S/M2R9B7iwf+R2GMV267kQCfIpQiGX+2C3aHwjFHjaEiPBF0aPOyBkHV2OfB3l7XSzyLIXYuQHQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
-
-  '@sanity/prettier-config@1.0.3':
-    resolution: {integrity: sha512-daeoWaW67I2t3yIV1s3PI2o8+A7jZnucFQzaIphpFDhHYM/mqjNvEROka300TcZ1Csm4VyPBSvx1IQQ/FkqA5Q==}
-    peerDependencies:
-      prettier: ^3.2.5
 
   '@sanity/preview-url-secret@4.1.0':
     resolution: {integrity: sha512-Zha42V94Q7vnSHOyCHtSihChX7asoVrDq7BCQ6xyAzoGZKdbP7FIOiSahfIN9Z1ZUEe5PJh6/HGx9+6e/y50NA==}
@@ -4533,6 +4632,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -4711,17 +4811,9 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
-  detect-indent@7.0.1:
-    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
-    engines: {node: '>=12.20'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  detect-newline@4.0.1:
-    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -5306,10 +5398,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stdin@9.0.0:
-    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
-    engines: {node: '>=12'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -5332,9 +5420,6 @@ packages:
   get-uri@6.0.4:
     resolution: {integrity: sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==}
     engines: {node: '>= 14'}
-
-  git-hooks-list@3.2.0:
-    resolution: {integrity: sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -6750,6 +6835,19 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.61.0:
+    resolution: {integrity: sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -6996,14 +7094,6 @@ packages:
   prettier-plugin-astro@0.14.1:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
-
-  prettier-plugin-packagejson@2.5.8:
-    resolution: {integrity: sha512-BaGOF63I0IJZoudxpuQe17naV93BRtK8b3byWktkJReKEMX9CC4qdGUzThPDVO/AUhPzlqDiAXbp18U6X8wLKA==}
-    peerDependencies:
-      prettier: '>= 1.16.0'
-    peerDependenciesMeta:
-      prettier:
-        optional: true
 
   prettier@2.8.7:
     resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
@@ -7629,13 +7719,6 @@ packages:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
-  sort-object-keys@1.1.3:
-    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
-
-  sort-package-json@2.14.0:
-    resolution: {integrity: sha512-xBRdmMjFB/KW3l51mP31dhlaiFmqkHLfWTfZAno8prb/wbDxwBPWFpxB16GZbiPbYr3wL41H8Kx22QIDWRe8WQ==}
-    hasBin: true
-
   sorted-array-functions@1.3.0:
     resolution: {integrity: sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==}
 
@@ -7823,10 +7906,6 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  synckit@0.9.2:
-    resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -7890,6 +7969,10 @@ packages:
 
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -11390,10 +11473,65 @@ snapshots:
 
   '@oxc-project/types@0.137.0': {}
 
-  '@pkgjs/parseargs@0.11.0':
+  '@oxfmt/binding-android-arm-eabi@0.61.0':
     optional: true
 
-  '@pkgr/core@0.1.1': {}
+  '@oxfmt/binding-android-arm64@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.61.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.61.0':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -11944,7 +12082,7 @@ snapshots:
       - terser
       - yaml
 
-  '@sanity/cli@6.7.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)':
+  '@sanity/cli@6.7.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)':
     dependencies:
       '@oclif/core': 4.11.11
       '@oclif/plugin-help': 6.2.52
@@ -11952,7 +12090,7 @@ snapshots:
       '@sanity/cli-build': 0.2.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)
       '@sanity/cli-core': 1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0)
       '@sanity/client': 7.24.0
-      '@sanity/codegen': 6.1.2(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(react@19.2.7)
+      '@sanity/codegen': 6.1.2(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(oxfmt@0.61.0)(react@19.2.7)
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.2.0
       '@sanity/generate-help-url': 4.0.0
@@ -12034,7 +12172,7 @@ snapshots:
       - utf-8-validate
       - xstate
 
-  '@sanity/cli@7.4.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/node@22.13.4)(@types/react@19.2.7)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(rolldown@1.1.3)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)':
+  '@sanity/cli@7.4.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/node@22.13.4)(@types/react@19.2.7)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.61.0)(rolldown@1.1.3)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)':
     dependencies:
       '@oclif/core': 4.11.11
       '@oclif/plugin-help': 6.2.52
@@ -12042,7 +12180,7 @@ snapshots:
       '@sanity/cli-build': 1.1.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(rolldown@1.1.3)(terser@5.39.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       '@sanity/cli-core': 2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0)
       '@sanity/client': 7.24.0
-      '@sanity/codegen': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(react@19.2.7)
+      '@sanity/codegen': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(oxfmt@0.61.0)(react@19.2.7)
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.2.0
       '@sanity/generate-help-url': 4.0.0
@@ -12141,7 +12279,7 @@ snapshots:
       nanoid: 3.3.15
       rxjs: 7.8.2
 
-  '@sanity/codegen@6.1.2(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(react@19.2.7)':
+  '@sanity/codegen@6.1.2(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(oxfmt@0.61.0)(react@19.2.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -12166,11 +12304,13 @@ snapshots:
       reselect: 5.2.0
       tsconfig-paths: 4.2.0
       zod: 4.4.3
+    optionalDependencies:
+      oxfmt: 0.61.0
     transitivePeerDependencies:
       - react
       - supports-color
 
-  '@sanity/codegen@7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(react@19.2.7)':
+  '@sanity/codegen@7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(oxfmt@0.61.0)(react@19.2.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -12195,6 +12335,8 @@ snapshots:
       reselect: 5.2.0
       tsconfig-paths: 4.2.0
       zod: 4.4.3
+    optionalDependencies:
+      oxfmt: 0.61.0
     transitivePeerDependencies:
       - react
       - supports-color
@@ -12467,11 +12609,6 @@ snapshots:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/prettier-config@1.0.3(prettier@3.9.1)':
-    dependencies:
-      prettier: 3.9.1
-      prettier-plugin-packagejson: 2.5.8(prettier@3.9.1)
-
   '@sanity/preview-url-secret@4.1.0(@sanity/client@7.24.0)':
     dependencies:
       '@sanity/client': 7.24.0
@@ -12705,7 +12842,7 @@ snapshots:
     dependencies:
       uuid: 11.1.0
 
-  '@sanity/vision@5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@sanity/vision@5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.4
@@ -12731,7 +12868,7 @@ snapshots:
       react: 19.2.7
       react-rx: 4.2.2(react@19.2.7)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       styled-components: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -12742,44 +12879,7 @@ snapshots:
       - react-dom
       - react-is
 
-  '@sanity/vision@5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3))(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
-    dependencies:
-      '@codemirror/autocomplete': 6.20.3
-      '@codemirror/commands': 6.10.4
-      '@codemirror/lang-javascript': 6.2.5
-      '@codemirror/language': 6.12.4
-      '@codemirror/search': 6.7.1
-      '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
-      '@lezer/highlight': 1.2.3
-      '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
-      '@rexxars/react-split-pane': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@19.2.7)
-      '@sanity/lezer-groq': 1.0.4
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@sanity/uuid': 3.0.3
-      '@uiw/react-codemirror': 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.8.4)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.6)(codemirror@6.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      is-hotkey-esm: 1.0.0
-      json-2-csv: 5.5.10
-      json5: 2.2.3
-      lodash-es: 4.18.1
-      quick-lru: 5.1.1
-      react: 19.2.7
-      react-rx: 4.2.2(react@19.2.7)(rxjs@7.8.2)
-      rxjs: 7.8.2
-      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
-      styled-components: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    transitivePeerDependencies:
-      - '@babel/runtime'
-      - '@codemirror/lint'
-      - '@codemirror/theme-one-dark'
-      - '@emotion/is-prop-valid'
-      - codemirror
-      - react-dom
-      - react-is
-
-  '@sanity/vision@6.2.0(ewqdenbiawvpe6jazzn42q2tzy)':
+  '@sanity/vision@6.2.0(4wo6afo3dnmdlw2vy6mr2wab44)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.4
@@ -12805,7 +12905,7 @@ snapshots:
       react: 19.2.7
       react-rx: 4.2.2(react@19.2.7)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(immer@10.2.0)(jiti@2.7.0)(node-fetch@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
+      sanity: 6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(immer@10.2.0)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3)
       styled-components: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -14711,11 +14811,7 @@ snapshots:
 
   destr@2.0.5: {}
 
-  detect-indent@7.0.1: {}
-
   detect-libc@2.1.2: {}
-
-  detect-newline@4.0.1: {}
 
   detect-node-es@1.1.0: {}
 
@@ -15022,7 +15118,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -15048,7 +15144,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.12
@@ -15067,7 +15163,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -15534,8 +15630,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stdin@9.0.0: {}
-
   get-stream@6.0.1: {}
 
   get-stream@9.0.1:
@@ -15564,8 +15658,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  git-hooks-list@3.2.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -17267,6 +17359,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.61.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.61.0
+      '@oxfmt/binding-android-arm64': 0.61.0
+      '@oxfmt/binding-darwin-arm64': 0.61.0
+      '@oxfmt/binding-darwin-x64': 0.61.0
+      '@oxfmt/binding-freebsd-x64': 0.61.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.61.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.61.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.61.0
+      '@oxfmt/binding-linux-arm64-musl': 0.61.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.61.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.61.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.61.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.61.0
+      '@oxfmt/binding-linux-x64-gnu': 0.61.0
+      '@oxfmt/binding-linux-x64-musl': 0.61.0
+      '@oxfmt/binding-openharmony-arm64': 0.61.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.61.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.61.0
+      '@oxfmt/binding-win32-x64-msvc': 0.61.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -17512,13 +17628,7 @@ snapshots:
       '@astrojs/compiler': 2.12.2
       prettier: 3.9.1
       sass-formatter: 0.7.9
-
-  prettier-plugin-packagejson@2.5.8(prettier@3.9.1):
-    dependencies:
-      sort-package-json: 2.14.0
-      synckit: 0.9.2
-    optionalDependencies:
-      prettier: 3.9.1
+    optional: true
 
   prettier@2.8.7:
     optional: true
@@ -18045,7 +18155,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  s.color@0.0.15: {}
+  s.color@0.0.15:
+    optional: true
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -18072,7 +18183,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3):
+  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.5.0
@@ -18096,7 +18207,7 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 6.7.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)
+      '@sanity/cli': 6.7.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)
       '@sanity/client': 7.24.0
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
@@ -18208,7 +18319,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3):
+  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@10.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.5.0
@@ -18232,7 +18343,7 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 6.7.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)
+      '@sanity/cli': 6.7.2(@noble/hashes@2.2.0)(@types/node@22.13.4)(@types/react@19.2.7)(jiti@2.7.0)(lightningcss@1.32.0)(oxfmt@0.61.0)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)
       '@sanity/client': 7.24.0
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
@@ -18344,7 +18455,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  sanity@6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(immer@10.2.0)(jiti@2.7.0)(node-fetch@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3):
+  sanity@6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/cli-core@2.1.1(@noble/hashes@2.2.0)(@types/node@22.13.4)(esbuild@0.28.1)(terser@5.39.0)(yaml@2.9.0))(@types/node@22.13.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(immer@10.2.0)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.61.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.39.0)(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.5.0
@@ -18368,7 +18479,7 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 7.4.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/node@22.13.4)(@types/react@19.2.7)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(rolldown@1.1.3)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)
+      '@sanity/cli': 7.4.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.13.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/node@22.13.4)(@types/react@19.2.7)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.61.0)(rolldown@1.1.3)(terser@5.39.0)(typescript@5.9.3)(xstate@5.32.5)
       '@sanity/client': 7.24.0
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
@@ -18491,6 +18602,7 @@ snapshots:
   sass-formatter@0.7.9:
     dependencies:
       suf-log: 2.5.3
+    optional: true
 
   satteri@0.9.3:
     dependencies:
@@ -18742,19 +18854,6 @@ snapshots:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
 
-  sort-object-keys@1.1.3: {}
-
-  sort-package-json@2.14.0:
-    dependencies:
-      detect-indent: 7.0.1
-      detect-newline: 4.0.1
-      get-stdin: 9.0.0
-      git-hooks-list: 3.2.0
-      is-plain-obj: 4.1.0
-      semver: 7.8.5
-      sort-object-keys: 1.1.3
-      tinyglobby: 0.2.17
-
   sorted-array-functions@1.3.0: {}
 
   source-map-js@1.2.1: {}
@@ -18928,6 +19027,7 @@ snapshots:
   suf-log@2.5.3:
     dependencies:
       s.color: 0.0.15
+    optional: true
 
   supports-color@5.5.0:
     dependencies:
@@ -18959,11 +19059,6 @@ snapshots:
       upper-case: 1.1.3
 
   symbol-tree@3.2.4: {}
-
-  synckit@0.9.2:
-    dependencies:
-      '@pkgr/core': 0.1.1
-      tslib: 2.8.1
 
   tagged-tag@1.0.0: {}
 
@@ -19053,6 +19148,8 @@ snapshots:
     dependencies:
       '@types/tinycolor2': 1.4.6
       tinycolor2: 1.6.0
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.0.3: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces Prettier with [Oxfmt](https://oxc.rs/docs/guide/usage/formatter), using the same formatter settings as [`sanity-io/react-rx`](https://github.com/sanity-io/react-rx/blob/main/.oxfmtrc.json).

### Changes
- Add `.oxfmtrc.json` with react-rx-aligned options (`printWidth: 100`, `semi: false`, `singleQuote: true`, `bracketSpacing: false`, `quoteProps: "consistent"`, `sortImports: true`, `sortPackageJson.sortScripts: true`)
- Replace `prettier`, `prettier-plugin-astro`, and `@sanity/prettier-config` with `oxfmt`
- Update `pnpm format` to run `oxfmt`
- Rename the auto-format workflow from Prettier → Format
- Reformat the repo with Oxfmt

### Notes
- Oxfmt does not format `.astro` files yet (Astro support is still pending upstream), so those remain unchanged.
- `pnpm oxfmt --check` passes; `@sanity/astro` unit tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4726759f-3bc4-4860-8dd2-278414867032?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4726759f-3bc4-4860-8dd2-278414867032&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

