### PR TITLE
fix: allow `@sanity/client` v8

### DIFF
--- a/apps/example-latest/README.md
+++ b/apps/example-latest/README.md
@@ -6,7 +6,7 @@ This example application is the same as the [`example`](../../example) app, but 
 - `@astrojs/react` 6
 - `@astrojs/prism` 4
 - Sanity 6
-- `@sanity/client` 7
+- `@sanity/client` 8
 - `@sanity/image-url` 2
 
 It renders the Sanity.io blog using Astro and shows how to configure the Sanity + Astro integration in `astro.config.mjs`, query and display Sanity content in `src/pages/index.astro` and `src/pages/posts/[slug].astro`, render Portable Text in `src/components/PortableText.astro`, and present Sanity images in `src/components/SanityImage.astro`.

--- a/apps/example-latest/package.json
+++ b/apps/example-latest/package.json
@@ -15,7 +15,7 @@
     "@astrojs/prism": "^4.0.2",
     "@astrojs/react": "^6.0.0",
     "@sanity/astro": "workspace:^",
-    "@sanity/client": "^7.24.0",
+    "@sanity/client": "^8.2.0",
     "@sanity/image-url": "^2.1.1",
     "@sanity/vision": "^6.2.0",
     "astro": "^7.0.3",

--- a/apps/example-ssr/package.json
+++ b/apps/example-ssr/package.json
@@ -16,7 +16,7 @@
     "@astrojs/react": "^4.4.1",
     "@astrojs/vercel": "^8.2.11",
     "@sanity/astro": "workspace:^",
-    "@sanity/client": "^7.24.0",
+    "@sanity/client": "^8.2.0",
     "@sanity/image-url": "^1.2.0",
     "@sanity/ui": "^3.2.0",
     "@sanity/vision": "^5.31.1",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -15,7 +15,7 @@
     "@astrojs/prism": "^3.3.0",
     "@astrojs/react": "^4.4.1",
     "@sanity/astro": "workspace:^",
-    "@sanity/client": "^7.24.0",
+    "@sanity/client": "^8.2.0",
     "@sanity/image-url": "^1.2.0",
     "@sanity/ui": "^3.2.0",
     "@sanity/vision": "^5.31.1",

--- a/apps/movies/package.json
+++ b/apps/movies/package.json
@@ -15,7 +15,7 @@
     "@astrojs/react": "^4.4.1",
     "@astrojs/vercel": "^8.2.11",
     "@sanity/astro": "workspace:^",
-    "@sanity/client": "^7.24.0",
+    "@sanity/client": "^8.2.0",
     "@sanity/ui": "^3.2.0",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",

--- a/packages/sanity-astro/package.json
+++ b/packages/sanity-astro/package.json
@@ -65,7 +65,7 @@
     "history": "^5.3.0"
   },
   "devDependencies": {
-    "@sanity/client": "^7.24.0",
+    "@sanity/client": "^8.2.0",
     "@types/serialize-javascript": "^5.0.4",
     "astro": "5.11.1",
     "playwright": "^1.52.0",
@@ -79,7 +79,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.14.1",
+    "@sanity/client": "^7.14.1 || ^8.0.0",
     "astro": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "react": "^18.2.0 || ^19.0.0",
     "react-dom": "^18.2.0 || ^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/sanity-astro
       '@sanity/client':
-        specifier: ^7.24.0
-        version: 7.24.0
+        specifier: ^8.2.0
+        version: 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/image-url':
         specifier: ^1.2.0
         version: 1.2.0
@@ -94,8 +94,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/sanity-astro
       '@sanity/client':
-        specifier: ^7.24.0
-        version: 7.24.0
+        specifier: ^8.2.0
+        version: 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/image-url':
         specifier: ^2.1.1
         version: 2.1.1
@@ -148,8 +148,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/sanity-astro
       '@sanity/client':
-        specifier: ^7.24.0
-        version: 7.24.0
+        specifier: ^8.2.0
+        version: 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/image-url':
         specifier: ^1.2.0
         version: 1.2.0
@@ -193,8 +193,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/sanity-astro
       '@sanity/client':
-        specifier: ^7.24.0
-        version: 7.24.0
+        specifier: ^8.2.0
+        version: 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/ui':
         specifier: ^3.2.0
         version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -239,7 +239,7 @@ importers:
     dependencies:
       '@sanity/visual-editing':
         specifier: ^5.5.0
-        version: 5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.24.0)(@types/react@19.2.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/react@19.2.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -251,8 +251,8 @@ importers:
         version: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@sanity/client':
-        specifier: ^7.24.0
-        version: 7.24.0
+        specifier: ^8.2.0
+        version: 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
@@ -3962,6 +3962,10 @@ packages:
     resolution: {integrity: sha512-YfXm/MzcknFiOe4Y5nYIFEhqqYwrQaWt7f4Vy3sbt3ZbDbd8oMoPaQ/WeSSbWFkHV8RFm01dE16u4Z1VNude+g==}
     engines: {node: '>=20'}
 
+  '@sanity/client@8.2.0':
+    resolution: {integrity: sha512-SK2o8uh9ayAYAHJtKvd3r78Y5QHlV6RA1H249rYXtm71rdvp4dVvQyf3E/QtYVaeIhrWufK1Mh7sbX6FDVLtWQ==}
+    engines: {node: '>=22.12.0'}
+
   '@sanity/codegen@6.1.2':
     resolution: {integrity: sha512-b9jph5tBeQgF5y4ta7fD2tkB8Xdf9vC2ryVx2X71guv/0Gy9YT46lQFQyStC+SfG8ugXjGzgRwbMo9UBvniu/g==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -6688,6 +6692,10 @@ packages:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@4.0.0:
+    resolution: {integrity: sha512-aIpvYxbqTx4KYWw73KpCt1Rh22tEAJ144F1qR76CT3Ex+LNMEPKf5HFrK5Yz9fMP1EVT0GrfA35VZvWQhMPuSQ==}
+    engines: {node: '>=22.12'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
@@ -6699,6 +6707,10 @@ packages:
   eventsource@4.1.0:
     resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
     engines: {node: '>=20.0.0'}
+
+  eventsource@5.1.0:
+    resolution: {integrity: sha512-+errgX9LYbcpibagHh7CEjEZJvQbIDZB2yY7SbUAhHGv4Ircri3T9LH33TUtcXHDy/pFYel1xCi4VOcBnr3wmw==}
+    engines: {node: '>=22.12.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -7063,6 +7075,15 @@ packages:
   get-it@8.8.0:
     resolution: {integrity: sha512-vRyooMBzoIdEbARGT3JcvWqMD67YzC5SKlMqofyfck1ebLh2zzlpD4hVQ3xiuuiADk4jNs0rTezVlxCMqOlZfA==}
     engines: {node: '>=14.0.0'}
+
+  get-it@9.5.1:
+    resolution: {integrity: sha512-XCVgepH7ROA/VEW4iaorxII3ZqQt7bqNhRNdeOklqwWsl7iGuJCGL7jxkUzcWVpK5zsYr0WaMqeXrIfeL02Uig==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   get-latest-version@6.0.1:
     resolution: {integrity: sha512-6Zub9FhioDbCJzGTZtetVvAkLeA5UnvQEbKfFZUc62hcZm3gO3Txr21oRGOcT6SdiKhjI0vWd/Jxct+wuLJgHA==}
@@ -8682,6 +8703,11 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
+    hasBin: true
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -8863,6 +8889,10 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -10829,10 +10859,6 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
-    engines: {node: '>=18.17'}
-
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -11772,17 +11798,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.10
       '@octokit/request-error': 7.1.0
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@actions/io@3.0.2': {}
 
@@ -16241,6 +16267,16 @@ snapshots:
       nanoid: 3.3.15
       rxjs: 7.8.2
 
+  '@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      eventsource: 5.1.0
+      get-it: 9.5.1(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
+      nanoid: 6.0.1
+      obug: 2.1.4
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - vitest
+
   '@sanity/codegen@6.1.2(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@22.13.4)(lightningcss@1.32.0)(terser@5.39.0)(yaml@2.9.0))(oxfmt@0.61.0)(react@19.2.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -16563,10 +16599,10 @@ snapshots:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))':
+  '@sanity/presentation-comlink@2.2.0(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
@@ -16574,6 +16610,11 @@ snapshots:
   '@sanity/preview-url-secret@4.1.0(@sanity/client@7.24.0)':
     dependencies:
       '@sanity/client': 7.24.0
+      '@sanity/uuid': 3.0.3
+
+  '@sanity/preview-url-secret@4.1.0(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))':
+    dependencies:
+      '@sanity/client': 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/uuid': 3.0.3
 
   '@sanity/prism-groq@1.1.2(prismjs@1.30.0)':
@@ -16915,10 +16956,10 @@ snapshots:
       - react-dom
       - react-is
 
-  '@sanity/visual-editing-csm@3.0.11(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))(typescript@5.9.3)':
+  '@sanity/visual-editing-csm@3.0.11(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))(typescript@5.9.3)':
     dependencies:
-      '@sanity/client': 7.24.0
-      '@sanity/visual-editing-types': 2.0.10(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))
+      '@sanity/client': 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@sanity/visual-editing-types': 2.0.10(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))
       valibot: 1.4.2(typescript@5.9.3)
     transitivePeerDependencies:
       - '@sanity/types'
@@ -16936,28 +16977,28 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 6.2.0(@types/react@19.2.7)
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))':
     dependencies:
-      '@sanity/client': 7.24.0
+      '@sanity/client': 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@sanity/types': 6.5.0(@types/react@19.2.7)
 
-  '@sanity/visual-editing-types@2.0.10(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))':
+  '@sanity/visual-editing-types@2.0.10(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))':
     dependencies:
-      '@sanity/client': 7.24.0
+      '@sanity/client': 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@sanity/types': 6.5.0(@types/react@19.2.7)
 
-  '@sanity/visual-editing@5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.24.0)(@types/react@19.2.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
+  '@sanity/visual-editing@5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/react@19.2.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 5.2.0(react@19.2.7)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
-      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))
-      '@sanity/preview-url-secret': 4.1.0(@sanity/client@7.24.0)
+      '@sanity/presentation-comlink': 2.2.0(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))
+      '@sanity/preview-url-secret': 4.1.0(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@sanity/types': 6.5.0(@types/react@19.2.7)
       '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@sanity/visual-editing-csm': 3.0.11(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.7))(typescript@5.9.3)
+      '@sanity/visual-editing-csm': 3.0.11(@sanity/client@8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)))(@sanity/types@6.5.0(@types/react@19.2.7))(typescript@5.9.3)
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
       lodash-es: 4.18.1
@@ -16969,7 +17010,7 @@ snapshots:
       styled-components: 6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       xstate: 5.32.5
     optionalDependencies:
-      '@sanity/client': 7.24.0
+      '@sanity/client': 8.2.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'
@@ -19718,7 +19759,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -19744,7 +19785,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.12
@@ -19763,7 +19804,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -19958,15 +19999,21 @@ snapshots:
 
   eventsource-parser@3.1.1: {}
 
+  eventsource-parser@4.0.0: {}
+
   eventsource@2.0.2: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.2
+      eventsource-parser: 3.1.1
 
   eventsource@4.1.0:
     dependencies:
-      eventsource-parser: 3.0.2
+      eventsource-parser: 3.1.1
+
+  eventsource@5.1.0:
+    dependencies:
+      eventsource-parser: 4.0.0
 
   execa@5.1.1:
     dependencies:
@@ -20442,6 +20489,12 @@ snapshots:
       is-retry-allowed: 2.2.0
       through2: 4.0.2
       tunnel-agent: 0.6.0
+
+  get-it@9.5.1(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      undici: 7.28.0
+    optionalDependencies:
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.13.4)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)
 
   get-latest-version@6.0.1:
     dependencies:
@@ -22403,6 +22456,8 @@ snapshots:
 
   nanoid@5.1.16: {}
 
+  nanoid@6.0.1: {}
+
   napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
@@ -22606,6 +22661,8 @@ snapshots:
       rxjs: 7.8.2
 
   obug@2.1.1: {}
+
+  obug@2.1.4: {}
 
   ofetch@1.5.1:
     dependencies:
@@ -25584,8 +25641,6 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
-
-  undici@6.27.0: {}
 
   undici@6.28.0: {}
 


### PR DESCRIPTION
Self explanatory probably. Would be nice to get this up to the `^22.12` baseline the other repos use, but no biggie so left it for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and peer-range changes only; no runtime logic in the package was modified, though v8 raises the client Node baseline (>=22.12.0).
> 
> **Overview**
> **`@sanity/astro`** now declares **`@sanity/client`** as a peer dependency for both v7 and v8 (`^7.14.1 || ^8.0.0`), so consumers can install client 8 without peer warnings.
> 
> The monorepo moves its own usage to **`@sanity/client` ^8.2.0** in **`packages/sanity-astro`** (dev) and in the example apps (`example`, `example-ssr`, `example-latest`, `movies`), with **`pnpm-lock.yaml`** refreshed for the v8 stack (e.g. `get-it` 9.x). **`example-latest`** README lists client 8 instead of 7.
> 
> There are no integration source changes in this diff—only dependency and lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b76c261ad04644bdf5d336088f62a2a0aa78c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->