### PR TITLE
fix: report the preview URL to Presentation on history subscribe

### DIFF
--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -135,6 +135,9 @@ export function VisualEditingComponent(props: VisualEditingOptions) {
         const currentUrl = getPresentationUrl(window.location)
         lastUrlRef.current = currentUrl
         lastPublishedAtRef.current = Date.now()
+        // Report the URL on every subscribe, since Presentation can't navigate the frame
+        // until it has one and an MPA has no router event to report it from.
+        _navigate({type: 'push', title: document.title, url: currentUrl})
         return () => {
           // Keep navigation publishing alive briefly for immediate link clicks
           // after edit mode is toggled off, then release it to respect off mode.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What this PR is

An in-repo replay of #421 by @skezo. That PR comes from a fork, so GitHub Actions and Vercel checks cannot access repository secrets and never run. This branch lives in `sanity-io/sanity-astro` so CI and the Vercel preview can execute.

The change is identical to the original commit 251865ee3666fadc1e85267cb6897c1160bb446f, replayed onto current `main` via `git cherry-pick --no-commit` (no merge commit). #421 is left open and the fork branch is untouched.

### Author credit

All code in this PR was written by **@skezo** (`skezo <793287+skezo@users.noreply.github.com>`). The commit carries a `Co-authored-by: skezo <793287+skezo@users.noreply.github.com>` trailer and `Refs: #421`. **When squash-merging, please keep the `Co-authored-by` trailer in the squash commit** so GitHub attributes the contribution correctly.

This repo releases via `release-please` from conventional commits (there is no `.changeset/` directory), so the `fix:` commit title and body are what produce the changelog entry; no changeset file is added.

### What the fix does

Typing a path into Presentation's address bar does nothing until you've clicked a link inside the preview.

`PresentationTool` gates the effect that drives the frame on `frameStateRef.current.url` being set, so it can't navigate until the frame has reported a URL. With the default history adapter on an MPA nothing reports one: a routed app publishes from a load-time history event, and `syncCurrentUrl()` can't cover it because `lastUrlRef` already matches by the time `navigateRef` is assigned, so `shouldPublishUrl` suppresses it. Link clicks worked because those force-publish.

This reports `currentUrl` from `defaultHistory.subscribe`, so Presentation has a frame URL from first load and it also fires on comlink reconnect. Re-reporting an unchanged URL is cheap: the `visual-editing/navigate` handler only calls `handleNavigate` when the incoming URL differs from the one it holds. Only `defaultHistory` is touched, so anyone passing their own `history` adapter is unaffected.

### Diff

One file, +3 lines: `packages/sanity-astro/src/visual-editing/visual-editing-component.tsx`.

### Verification

- `tsc --noEmit -p packages/sanity-astro/tsconfig.json`: clean
- `oxfmt --check` on the touched file: clean
- `pnpm --filter @sanity/astro test`: 6 files, 26 tests passed
- `pnpm --filter @sanity/astro build`: succeeds

Related: #420.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-404d138b-f078-4943-a867-386c7e03f968?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-404d138b-f078-4943-a867-386c7e03f968&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

