### PR TITLE
fix(studio): allow embedded Studio layout to scroll on small screens

### DIFF
--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -98,7 +98,7 @@ export function StudioComponent(props: {history?: 'browser' | 'hash'}) {
         maxHeight: '100dvh',
         overscrollBehavior: 'none',
         WebkitFontSmoothing: 'antialiased',
-        overflow: 'hidden',
+        overflow: 'auto',
       }}
     >
       <Studio config={config} unstable_history={history} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Re-lands #410 by [@Spratch](https://github.com/Spratch) from an in-repo branch so that Vercel / GitHub Actions secrets are available to CI. The original fork PR is left open and untouched.

Changes the `AstroStudioLayout` wrapper's `overflow` from `hidden` to `auto` in `packages/sanity-astro/src/studio/studio-component.tsx`, so the embedded Studio is scrollable on small viewports. This matches [`NextStudioLayout`](https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/src/studio/NextStudioLayout.tsx) in next-sanity.

### Release

This repo uses release-please with conventional commits (no Changesets). The `fix:` commit type produces a **patch** bump of `@sanity/astro` and a CHANGELOG entry. The commit carries `Co-authored-by: Spratch <contact@josephclenet.fr>` and is authored by Spratch, so credit is preserved on squash-merge.

### Verification

- `pnpm oxfmt --check packages/sanity-astro/src/studio/studio-component.tsx` — clean
- `tsc --noEmit -p packages/sanity-astro` — 0 errors
- `pnpm --filter @sanity/astro build` — succeeds
- `pnpm --filter @sanity/astro test` — 26/26 pass

### Note from the original PR

As noted in #410, with `overflow: auto` the Studio navbar is no longer fixed/sticky on small screens. This PR intentionally keeps the change minimal and identical to the original.

Co-authored-by: Spratch <contact@josephclenet.fr>
Refs #410
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1b91b73-2c7d-4610-a1e3-f9a5f59134e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1b91b73-2c7d-4610-a1e3-f9a5f59134e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

