### PR TITLE
feat: forward all VisualEditingOptions on VisualEditingComponent

### DIFF
--- a/.changeset/forward-visual-editing-options.md
+++ b/.changeset/forward-visual-editing-options.md
@@ -1,7 +1,0 @@
----
-'@sanity/astro': minor
----
-
-`VisualEditingComponent` now forwards every `VisualEditingOptions` prop to `<VisualEditing />` from `@sanity/visual-editing/react`, including `onPerspectiveChange` and the alpha `components` / `plugins` resolvers. `refresh` and `history` keep their existing defaults when omitted.
-
-Thanks to [@skezo](https://github.com/skezo) — re-land of [#420](https://github.com/sanity-io/sanity-astro/pull/420).

--- a/.changeset/forward-visual-editing-options.md
+++ b/.changeset/forward-visual-editing-options.md
@@ -1,0 +1,7 @@
+---
+'@sanity/astro': minor
+---
+
+`VisualEditingComponent` now forwards every `VisualEditingOptions` prop to `<VisualEditing />` from `@sanity/visual-editing/react`, including `onPerspectiveChange` and the alpha `components` / `plugins` resolvers. `refresh` and `history` keep their existing defaults when omitted.
+
+Thanks to [@skezo](https://github.com/skezo) — re-land of [#420](https://github.com/sanity-io/sanity-astro/pull/420).

--- a/packages/sanity-astro/README.md
+++ b/packages/sanity-astro/README.md
@@ -329,7 +329,9 @@ const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLE
 </body>
 ```
 
-The `payload` tells you why the refresh fired: `payload.source` is `'manual'` when the editor clicks refresh in Presentation, or `'mutation'` when a document changes. The same subpath also accepts `history` if you need to take over URL syncing, and `onSuspiciousStega` for opt-in reporting when stega appears in unsafe placements (`class`, `href`, `<head>`, scripts, and similar).
+The `payload` tells you why the refresh fired: `payload.source` is `'manual'` when the editor clicks refresh in Presentation, or `'mutation'` when a document changes.
+
+`VisualEditingComponent` accepts every option that `<VisualEditing />` from `@sanity/visual-editing/react` does, and forwards them all. Beyond `refresh`, the ones worth knowing about are `history` if you need to take over URL syncing, `onSuspiciousStega` for opt-in reporting when stega appears in unsafe placements (`class`, `href`, `<head>`, scripts, and similar), `onPerspectiveChange` to keep server-side fetching on the same perspective as the Studio driving the preview, and the alpha `components` / `plugins` resolvers for custom overlay UI such as an insert menu on an array field. `refresh` and `history` fall back to the defaults above when you don't pass them; everything else is passed straight through.
 
 ### 2. Add the Presentation tool to the Studio
 

--- a/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
+++ b/packages/sanity-astro/src/visual-editing/visual-editing-component.tsx
@@ -9,10 +9,7 @@ import {applyPresentationHistoryUpdate, getPresentationUrl, shouldPublishUrl} fr
 
 export type {SuspiciousStegaReport}
 
-export type VisualEditingOptions = Pick<
-  InternalVisualEditingOptions,
-  'zIndex' | 'refresh' | 'history' | 'keepStegaOnCopy' | 'onSuspiciousStega'
->
+export type VisualEditingOptions = InternalVisualEditingOptions
 type HistoryAdapter = NonNullable<InternalVisualEditingOptions['history']>
 type HistoryNavigate = Parameters<HistoryAdapter['subscribe']>[0]
 
@@ -158,12 +155,10 @@ export function VisualEditingComponent(props: VisualEditingOptions) {
 
   return (
     <InternalVisualEditing
+      {...props}
       portal
       history={props.history ?? defaultHistory}
-      zIndex={props.zIndex}
       refresh={props.refresh ?? defaultRefresh}
-      keepStegaOnCopy={props.keepStegaOnCopy}
-      onSuspiciousStega={props.onSuspiciousStega}
     />
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Re-land of #420 by @skezo onto an in-repo branch so Vercel / GitHub Actions secrets are available to CI. #420 stays open; the fork is untouched. The `feat:` commit carries `Co-authored-by: skezo <793287+skezo@users.noreply.github.com>` and references the original commit 518058585c7dceb5b4d4d8698e6e365f094b9b98.

### Description

Follow-up to #401 and #417, which each widened the `Pick` to let one more option through. The list still left out the alpha `components` and `plugins` resolvers and `onPerspectiveChange`.

This forwards everything instead. `VisualEditingOptions` becomes an alias of the option type from `@sanity/visual-editing/react`, and props are spread onto the inner component. `portal`, `history` and `refresh` are applied after the spread so the current defaults still win; behaviour is unchanged for existing usage.

The `.astro` wrapper is untouched: it still narrows to what it can serialize through `client:only`, and its `Pick` resolves the same way against the wider type.

### What changed

- `packages/sanity-astro/src/visual-editing/visual-editing-component.tsx` (+2/−7): the unique change from 518058585c, replayed onto current `main` (applies cleanly on top of the `@sanity/visual-editing` v6 bump).
- `packages/sanity-astro/README.md` (+3/−1): documents that all options are forwarded.

Net diff against `main` is exactly the two files from #420 (+5/−8). Releases are handled by release-please from conventional commits; the `feat:` type yields the minor bump. (A changeset file was briefly added and reverted in this branch's history; it is not present in the final tree.)

### Verification

- `tsc --noEmit -p packages/sanity-astro/tsconfig.json`: clean.
- Probe component passing `components` / `onPerspectiveChange`: fails with TS2322 on `main`, compiles on this branch.
- `pnpm --filter @sanity/astro test`: 26/26 passing.
- `pnpm --filter @sanity/astro build`: clean.
- `pnpm oxfmt --check` on the touched files: clean.

Refs #401, #417, #420, #421.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e84ddc2-8f9b-4b4b-ac28-8db1f3270613?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e84ddc2-8f9b-4b4b-ac28-8db1f3270613&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

