### PR TITLE
fix: remove `lodash/startCase.js` from Vite optimizeDeps candidates

### DIFF
--- a/packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.ts
+++ b/packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.ts
@@ -30,7 +30,6 @@ export const SANITY_OPTIMIZE_DEPS_CANDIDATES = [
   'react-compiler-runtime',
   'react-is',
   'styled-components',
-  'lodash/startCase.js',
 ] as const
 
 function canResolveDependency(projectRoot: string, dependency: string): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Re-lands #394 by @scottmessinger (Scott Ames-Messinger) onto an in-repo branch so Vercel/GHA secrets are available to CI. #394 stays open; the fork is untouched. The commit carries `Co-authored-by: Scott Ames-Messinger <scott@commoncurriculum.com>`.

Removes `lodash/startCase.js` from the list Vite pre-bundles via `optimizeDeps.include`. `@sanity/astro` never imports it, and neither does any supported Sanity package anymore (`sanity` v5/v6 import `lodash-es/startCase.js`; `@sanity/ui` and `@sanity/visual-editing` don't import it at all). In projects without `lodash` installed the entry produced on every run:

```
[WARN] [vite] Failed to resolve dependency: lodash/startCase.js, present in client 'optimizeDeps.include'
```

### Differences from #394

- #394 edited `packages/sanity-astro/src/index.ts`. Since #411, the `optimizeDeps.include` list lives in `SANITY_OPTIMIZE_DEPS_CANDIDATES` in `packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.ts`, so the same one-line removal is applied there.
- #411 also guards candidates with `canResolveDependency` and only applies the plugin during `serve`, so the warning was already suppressed on `main`; this PR removes the now-dead candidate rather than relying on the runtime filter.
- Release notes: this repo uses release-please, not Changesets, so there is no changeset file to add. The `fix:` conventional commit produces a **patch** bump of `@sanity/astro`, and the commit body credits Scott and references #394.

### What to review

The one-line removal in `packages/sanity-astro/src/vite-plugin-sanity-module-dedupe.ts`.

### Testing

- `tsc --noEmit -p packages/sanity-astro/tsconfig.json` — clean
- `oxfmt --check` on the touched file — clean
- `pnpm --filter @sanity/astro test` — 6 files, 26 tests passed
- `pnpm --filter @sanity/astro build` — succeeds; `lodash` no longer appears in `dist/`
- Verified `lodash/startCase.js` is not resolvable from `packages/sanity-astro`, `apps/example`, `apps/example-latest`, or `apps/movies`, and that `sanity@5.31.1`/`sanity@6.2.0` only import `lodash-es/*`, never `lodash/*`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e02c60e3-e0fa-4b23-92cc-5e31451c2eef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e02c60e3-e0fa-4b23-92cc-5e31451c2eef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

