### PR TITLE
feat(visual-editing): reload once more after Studio edits arrive mid-refresh (#407)

### DIFF
--- a/packages/sanity-astro/src/visual-editing/visual-editing.astro
+++ b/packages/sanity-astro/src/visual-editing/visual-editing.astro
@@ -3,10 +3,54 @@ import {VisualEditingComponent, type VisualEditingOptions} from './visual-editin
 
 export interface Props extends Pick<VisualEditingOptions, 'zIndex' | 'keepStegaOnCopy'> {
   enabled?: boolean
+  assureTypingInterval?: number
 }
 
-const {enabled, zIndex, keepStegaOnCopy} = Astro.props
+const {enabled, assureTypingInterval = 1200, zIndex, keepStegaOnCopy} = Astro.props
 ---
+
+<!--
+  NOTE: 'define:vars' implicitly enforces 'is:inline' behavior.
+  Do not combine them, as it can cause compilation syntax conflicts.
+  We must define the var to have it passed from js section
+-->
+<script define:vars={{assureTypingInterval}}>
+  ;(function () {
+    // Only operate within the Studio's context,
+    // and if not defeated by negative value flag
+    if (window.self === window.top) return
+    if (assureTypingInterval <= 0) {
+      return
+    }
+
+    const FLAG = 'sanity_sync_needed'
+
+    // 1. OBSERVE: Monitor the Studio's snapshot stream
+    window.addEventListener('message', (e) => {
+      // Catching the v5.6+ Snapshot volume
+      if (e.data?.type === 'presentation/preview-snapshots') {
+        sessionStorage.setItem(FLAG, 'true')
+      }
+    })
+
+    // 2. RECONCILE: Check for missed updates on page arrival
+    window.addEventListener('load', () => {
+      const needsSync = sessionStorage.getItem(FLAG) === 'true'
+
+      if (needsSync) {
+        // Clear flag immediately to ensure idempotency
+        sessionStorage.removeItem(FLAG)
+
+        // The 'Humanistic' pause for recursive queries to settle
+        // n.b. we have to evaluate template-style, _and_ outside
+        // the function call. These are Astro rules....
+        setTimeout(() => {
+          window.location.reload()
+        }, assureTypingInterval) // must evaluate
+      }
+    })
+  })()
+</script>
 
 {
   enabled ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Re-lands #407 by **Narration SD** ([@narration-sd](https://github.com/narration-sd)) on an in-repo branch so Vercel/GHA secrets are available to CI. The fork PR stays open for reference; this does **not** close it.

When editing content in Presentation, Visual Editing for Astro refreshes the preview after a short pause. Keystrokes typed *during* that refresh land in the Content Lake but never trigger another refresh, so the preview silently lags the document. This adds a small inline helper to `<VisualEditing />` that:

1. Listens for `presentation/preview-snapshots` messages from the Studio (only when running inside the Presentation iframe) and sets a `sessionStorage` flag.
2. On the next page `load`, if the flag is set, clears it and schedules **one** corrective `location.reload()` after `assureTypingInterval` ms.

New prop: `assureTypingInterval?: number` (default `1200`; `<= 0` disables the helper). No behavior change outside the Presentation iframe.

Replayed onto current `main` (which now uses `Pick<VisualEditingOptions, ...>` and `keepStegaOnCopy`) as a single commit with `Co-authored-by: Narration SD <narration-sd@users.noreply.github.com>`. Versus the fork, the only intentional differences are: frontmatter merged with `main`, script restyled to the repo's no-semicolon style, and one dead `packetCount` counter (left over after the author removed the debug logging) dropped.

Release notes: this repo uses release-please with Conventional Commits (no Changesets directory), so the changelog entry comes from this PR's title. Typed as `feat` (minor) because it adds a public prop, matching how `#401`/`#417` were classified; switch the title to `fix(...)` before squash-merging if a patch is preferred.

### What to review

- `packages/sanity-astro/src/visual-editing/visual-editing.astro` (only file changed).
- The `<script define:vars>` is intentionally inline (the author's note explains why `is:inline` isn't combined with it); the Astro compiler emits only the expected "treated as is:inline" hint.
- The helper is emitted regardless of `enabled` (as in #407); it early-returns unless `window.self !== window.top`. Gating it on `enabled` would be a reasonable follow-up.

### Testing

- `pnpm --filter @sanity/astro build` (copies `src/visual-editing` into `dist`), `pnpm --filter @sanity/astro test` (26 passed).
- `astro check` in `apps/movies` with `assureTypingInterval={800}` passed on the component; a negative control (`assureTypingInterval="oops"`) correctly fails with `ts(2322)`.
- Rendered the component in the `example` dev server and confirmed the emitted `<script>` contains `const assureTypingInterval = 1200;` (default) and `= 0` (override).
- Headless Chromium behavioral test against the dev server, embedding the page in an iframe like Presentation does: plain reload → no extra reload; `presentation/preview-snapshots` message + refresh → exactly one corrective reload ≥1200 ms later and the flag is cleared (no loop); top-level page → no-op.

```
1. iframe loaded; navigations: 1
2. plain reload + 3.5s: navigations = 2 (expect 2)
3. flag set after snapshot message: true
4. simulated VE refresh committed at +1200ms; navigations = 3
5. corrective reload committed at +3600ms (2400ms after refresh; expect >=1200)
6. +3.5s later: navigations = 4 (expect 4: no reload loop)
7. flag cleared: true
8. top-level page flag (expect null): null
RESULT: PASS { scenarioA: true, scenarioB: true, scenarioC: true }
```

Co-authored-by: Narration SD <narration-sd@users.noreply.github.com>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c585c2-8192-4082-aa5a-40d501b71f38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c585c2-8192-4082-aa5a-40d501b71f38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

